### PR TITLE
extended functionalities for skim module

### DIFF
--- a/DataCont/interface/Array.h
+++ b/DataCont/interface/Array.h
@@ -29,7 +29,7 @@ namespace mithep
       ArrayElement        *At(UInt_t idx);
       const ArrayElement  *At(UInt_t idx)                       const;
       void                 Clear(Option_t */*opt*/="")                { fArray.~TClonesArray(); }
-      void                 Delete();
+      void                 Delete(Option_t *opt="");
       UInt_t               Entries()                            const { return fNumEntries; }
       UInt_t               GetEntries()                         const { return fNumEntries; }
       const char          *GetName()                            const { return fArray.GetName(); }
@@ -214,13 +214,17 @@ inline void mithep::Array<ArrayElement>::Reset()
 
 //--------------------------------------------------------------------------------------------------
 template<class ArrayElement>
-inline void mithep::Array<ArrayElement>::Delete()
+inline void mithep::Array<ArrayElement>::Delete(Option_t *opt)
 {
   // ROOT implementation for clearing the array, deleting all objects inside
 
   fArray.Delete();   //will call destructor for every element
   fNumEntries = 0;
   BaseCollection::Clear();
+
+  if (opt && opt[0] != 0) {
+  TObject::Warning("Delete","Delete option for Array class not implemented, using default implementation.");     
+  }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/PhysicsMod/src/SkimModLinkDef.h
+++ b/PhysicsMod/src/SkimModLinkDef.h
@@ -17,6 +17,8 @@
 #include "MitAna/DataTree/interface/JPTJet.h"
 #include "MitAna/DataTree/interface/PFJet.h"
 #include "MitAna/DataTree/interface/PFMet.h"
+#include "MitAna/DataTree/interface/Tau.h"
+#include "MitAna/DataTree/interface/PFTau.h"
 #include "MitAna/DataTree/interface/Photon.h"
 #include "MitAna/DataTree/interface/Track.h"
 #include "MitAna/DataTree/interface/SuperCluster.h"
@@ -36,7 +38,6 @@
 #pragma link C++ class mithep::SkimMod<mithep::CaloMet>+;
 #pragma link C++ class mithep::SkimMod<mithep::CaloTower>+;
 #pragma link C++ class mithep::SkimMod<mithep::CompositeParticle>+;
-#pragma link C++ class mithep::SkimMod<mithep::CompoundParticle>+;
 #pragma link C++ class mithep::SkimMod<mithep::Conversion>+;
 #pragma link C++ class mithep::SkimMod<mithep::Electron>+;
 #pragma link C++ class mithep::SkimMod<mithep::GenJet>+;
@@ -47,6 +48,8 @@
 #pragma link C++ class mithep::SkimMod<mithep::PFMet>+;
 #pragma link C++ class mithep::SkimMod<mithep::Muon>+;
 #pragma link C++ class mithep::SkimMod<mithep::PFJet>+;
+#pragma link C++ class mithep::SkimMod<mithep::Tau>+;
+#pragma link C++ class mithep::SkimMod<mithep::PFTau>+;
 #pragma link C++ class mithep::SkimMod<mithep::Photon>+;
 #pragma link C++ class mithep::SkimMod<mithep::SuperCluster>+;
 #pragma link C++ class mithep::SkimMod<mithep::Track>+;

--- a/TreeMod/src/OutputMod.cc
+++ b/TreeMod/src/OutputMod.cc
@@ -576,6 +576,21 @@ void OutputMod::SetupBranches()
 
     fTreeWriter->AddBranch(bname, cname, &fBranches[i], bsize);
   }
+
+  // deal here with additional published objects
+  for (UInt_t i=0; i<fAddList.size(); ++i) {
+    TString objname(fAddList.at(i));
+    TObject *obj = FindPublicObj(objname);
+    if (obj) {
+      fBranches[fNBranchesMax+i] = obj;
+      fTreeWriter->AddBranch(objname, obj->ClassName(), &fBranches[fNBranchesMax+i], fBranchSize);
+      Info("SlaveBegin", "Adding additional branch named '%s' as requested", objname.Data());
+    } else {
+      SendError(kAbortAnalysis, "SlaveBegin", 
+                "Object named '%s' for additional branch is NULL", objname.Data());
+    }
+  }
+
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -623,20 +638,6 @@ void OutputMod::SlaveBegin()
 
   // create TObject space for TAM
   fBranches = new TObject*[fNBranchesMax + fAddList.size()];       
-
-  // deal here with additional published objects
-  for (UInt_t i=0; i<fAddList.size(); ++i) {
-    TString objname(fAddList.at(i));
-    TObject *obj = FindPublicObj(objname);
-    if (obj) {
-      fBranches[fNBranchesMax+i] = obj;
-      fTreeWriter->AddBranch(objname, &fBranches[fNBranchesMax+i], 64*1024, 0);
-      Info("SlaveBegin", "Adding additional branch named '%s' as requested", objname.Data());
-    } else {
-      SendError(kAbortAnalysis, "SlaveBegin", 
-                "Object named '%s' for additional branch is NULL", objname.Data());
-    }
-  }
 
   // adjust checks for TAM branches
   if (fKeepTamBr)


### PR DESCRIPTION
Hi Christoph,
 this are the first batch of modifications. 
They will allow us to store in a structure tuple the collections produced 
during the typical analysis chain.

I have also prepared and committed a run macro which exploits these new
functionalities. Check it out here
https://github.com/dimatteo/MitMonoJet/blob/master/macros/runBoostedVntuple.C

An example of the output tuple is here:
/home/dimatteo/cms/root/boostedv_r12b-smu-j22-v1_noskim_0000_000.root
