### PR TITLE
bugfix for batch jobs using qjets

### DIFF
--- a/bin/setupExternal.sh
+++ b/bin/setupExternal.sh
@@ -52,4 +52,35 @@ cd $CMSSW_BASE/src
 scram setup fastjet
 cd -
 
+# Setup for qjets
+# -----------------
+
+# move the old setup out of the way
+echo ' moving old config out of the way'
+mv $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/qjets.xml \
+   $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/qjets.xml-last.$$
+
+# Generate qjets file from modified template
+echo \
+'
+  <tool name="qjets" version="2">
+    <info url="http://jets.physics.harvard.edu/Qjets/html/Welcome.html"/>
+    <lib name="qjets"/>
+    <client>
+      <environment name="QJETS_BASE" default="xx-PATH-xx/Qjets"/>
+      <environment name="LIBDIR" default="$QJETS_BASE/lib"/>
+      <environment name="INCLUDE" default="$QJETS_BASE"/>
+    </client>
+  </tool>
+' | sed "s#xx-PATH-xx#$EXTERNAL#" \
+> $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/qjets.xml
+
+# show the user what was created
+cat $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/qjets.xml
+
+# commit the scram config changes
+cd $CMSSW_BASE/src
+scram setup qjets
+cd -
+
 exit 0


### PR DESCRIPTION
Hey Christoph,

  this slipped from me before.
If we externalize some library we need to regenerate the 
library links unders $CMSSW_BASE/external otherwise
the jobs will fail badly.
