### PR TITLE
Bugfix and minor performance improvements

### DIFF
--- a/DataUtil/interface/TreeWriter.h
+++ b/DataUtil/interface/TreeWriter.h
@@ -32,7 +32,7 @@ namespace mithep
   {
     public:
       MyTree(const char* name, const char* title, Int_t splitlevel = 99) :
-	TTree(name,title, splitlevel), fAutoFill(1) {}
+	TTree(name,title, splitlevel), fAutoFill(true) {}
 	Bool_t GetAutoFill() const   { return fAutoFill; }
 	void   SetAutoFill(Bool_t b) { fAutoFill = b; }
 

--- a/PhysicsMod/dict/TemplateModsLinkDef.h
+++ b/PhysicsMod/dict/TemplateModsLinkDef.h
@@ -28,6 +28,7 @@
 #include "MitAna/DataTree/interface/Particle.h"
 #include "MitAna/DataTree/interface/Photon.h"
 #include "MitAna/DataTree/interface/SuperCluster.h"
+#include "MitAna/DataTree/interface/PFTau.h"
 #include "MitAna/DataTree/interface/Tau.h"
 #include "MitAna/DataTree/interface/Track.h"
 #include "MitAna/DataTree/interface/TriggerObject.h"

--- a/TreeMod/interface/HLTFwkMod.h
+++ b/TreeMod/interface/HLTFwkMod.h
@@ -20,34 +20,35 @@
 #include "MitAna/DataTree/interface/TriggerObjectBaseFwd.h"
 #include "MitAna/DataTree/interface/TriggerObjectFwd.h"
 #include "MitAna/DataTree/interface/TriggerObjectRelFwd.h"
+#include "MitAna/DataTree/interface/TriggerTable.h"
+#include "MitAna/DataTree/interface/TriggerObjectsTable.h"
 
 namespace mithep 
 {
-  class TriggerTable;
-  class TriggerObjectsTable;
-
   class HLTFwkMod : public BaseMod {
     public:
       HLTFwkMod(const char *name="HLTFwkMod", const char *title="HLT framework module");
       ~HLTFwkMod();
 
-      const char                 *L1ATabNamePub()  const { return fL1ATabNamePub; }
-      const char                 *L1TTabNamePub()  const { return fL1TTabNamePub; }
+      const char                 *L1ATabNamePub()  const { return fL1Algos->GetName(); }
+      const char                 *L1TTabNamePub()  const { return fTriggers->GetName(); }
       const char                 *HLTLabName()     const { return fHLTLabName;    }
-      const char                 *HLTLabNamePub()  const { return fHLTLabNamePub; }
+      const char                 *HLTLabNamePub()  const { return fLabels->GetName(); }
       const char                 *HLTObjsName()    const { return fObjsName;      }
-      const char                 *HLTObjsNamePub() const { return fObjsNamePub;   }
+      const char                 *HLTObjArrNamePub() const { return fTrigObjArr->GetName(); }
+      const char                 *HLTObjsNamePub() const { return fTrigObjs->GetName(); }
       const char                 *HLTTabName()     const { return fHLTTabName;    }
-      const char                 *HLTTabNamePub()  const { return fHLTTabNamePub; }
+      const char                 *HLTTabNamePub()  const { return fL1Techs->GetName(); }
       const char                 *HLTTreeName()    const { return fHLTTreeName;   }
-      void                        SetL1ATabName(const char *n)     { fL1ATabNamePub = n; }
-      void                        SetL1TTabName(const char *n)     { fL1TTabNamePub = n; }
+      void                        SetL1ATabName(const char *n)     { fL1Algos->SetName(n); }
+      void                        SetL1TTabName(const char *n)     { fL1Techs->SetName(n); }
       void                        SetHLTLabName(const char *n)     { fHLTLabName    = n; }
-      void                        SetHLTLabNamePub(const char *n)  { fHLTLabNamePub = n; }
+      void                        SetHLTLabNamePub(const char *n)  { fLabels->SetName(n); }
       void                        SetHLTObjsName(const char *n)    { fObjsName      = n; }
-      void                        SetHLTObjsNamePub(const char *n) { fObjsNamePub   = n; }
+      void                        SetHLTObjArrNamePub(const char *n) { fTrigObjArr->SetName(n); }
+      void                        SetHLTObjsNamePub(const char *n) { fTrigObjs->SetName(n); }
       void                        SetHLTTabName(const char *n)     { fHLTTabName    = n; }
-      void                        SetHLTTabNamePub(const char *n)  { fHLTTabNamePub = n; }
+      void                        SetHLTTabNamePub(const char *n)  { fTriggers->SetName(n); }
       void                        SetHLTTreeName(const char *n)    { fHLTTreeName   = n; }
 
     protected:
@@ -63,11 +64,6 @@ namespace mithep
       TString                     fHLTLabName;    //HLT module labels branch name
       TString                     fObjsName;      //trigger objects branch name
       TString                     fRelsName;      //trigger to objects relation branch name
-      TString                     fHLTTabNamePub; //HLT trigger names published qname
-      TString                     fHLTLabNamePub; //HLT module labels published name
-      TString                     fObjsNamePub;   //trigger objects published name
-      TString                     fL1ATabNamePub; //L1 algorithm trigger names published name
-      TString                     fL1TTabNamePub; //L1 technical trigger names published name
       const UInt_t                fNMaxTriggers;  //maximum number of triggers
       const TriggerObjectBaseArr *fObjs;          //!trigger objects branch
       const TriggerObjectRelArr  *fRels;          //!trigger to objects relation branch

--- a/TreeMod/interface/HLTFwkMod.h
+++ b/TreeMod/interface/HLTFwkMod.h
@@ -18,6 +18,7 @@
 #include <TString.h>
 #include "MitAna/TreeMod/interface/BaseMod.h" 
 #include "MitAna/DataTree/interface/TriggerObjectBaseFwd.h"
+#include "MitAna/DataTree/interface/TriggerObjectFwd.h"
 #include "MitAna/DataTree/interface/TriggerObjectRelFwd.h"
 
 namespace mithep 
@@ -77,6 +78,7 @@ namespace mithep
       Int_t                       fCurEnt;        //!current entry in HLT tree (-2 for unset)
       TriggerTable               *fTriggers;      //!exported published HLT trigger table
       TriggerTable               *fLabels;        //!exported published HLT module label table
+      TriggerObjectArr           *fTrigObjArr;    //!buffer of published HLT trigger objects
       TriggerObjectsTable        *fTrigObjs;      //!exported published HLT trigger objects table
       TriggerTable               *fL1Algos;       //!exported published L1 algorithm triggers table
       TriggerTable               *fL1Techs;       //!exported published L1 technical triggers table

--- a/TreeMod/src/HLTFwkMod.cc
+++ b/TreeMod/src/HLTFwkMod.cc
@@ -4,11 +4,9 @@
 #include "MitAna/DataUtil/interface/Debug.h"
 #include "MitAna/DataTree/interface/Names.h"
 #include "MitAna/DataTree/interface/TriggerName.h"
-#include "MitAna/DataTree/interface/TriggerTable.h"
 #include "MitAna/DataTree/interface/TriggerObjectBaseCol.h"
 #include "MitAna/DataTree/interface/TriggerObjectRelCol.h"
 #include "MitAna/DataTree/interface/TriggerObjectCol.h"
-#include "MitAna/DataTree/interface/TriggerObjectsTable.h"
 
 using namespace mithep;
 
@@ -23,11 +21,6 @@ HLTFwkMod::HLTFwkMod(const char *name, const char *title) :
   fHLTLabName(Names::gkHltLabelBrn),
   fObjsName(Names::gkHltObjBrn),
   fRelsName(Form("%sRelation",fObjsName.Data())),
-  fHLTTabNamePub(Form("%sFwk",fHLTTabName.Data())),
-  fHLTLabNamePub(Form("%sFwk",fHLTLabName.Data())),
-  fObjsNamePub(Form("%sFwk",fObjsName.Data())),
-  fL1ATabNamePub("L1AlgoTableFwk"),
-  fL1TTabNamePub("L1TechTableFwk"),
   fNMaxTriggers(1024),
   fObjs(0),
   fRels(0),
@@ -45,15 +38,15 @@ HLTFwkMod::HLTFwkMod(const char *name, const char *title) :
 {
   // Constructor.
 
-  fTriggers->SetName(fHLTTabNamePub);
+  fTriggers->SetName(fHLTTabName + "Fwk");
   fTriggers->SetOwner();
-  fLabels->SetName(fHLTLabNamePub);
+  fLabels->SetName(fHLTLabName + "Fwk");
   fLabels->SetOwner();
-  fTrigObjArr->SetName(Form("%sArr", fObjsName.Data()));
-  fTrigObjs->SetName(fObjsNamePub);
-  fL1Algos->SetName(fL1ATabNamePub);
+  fTrigObjArr->SetName(fObjsName + "Arr");
+  fTrigObjs->SetName(fObjsName + "Fwk");
+  fL1Algos->SetName("L1AlgoTableFwk");
   fL1Algos->SetOwner();
-  fL1Techs->SetName(fL1TTabNamePub);
+  fL1Techs->SetName("L1TechTableFwk");
   fL1Techs->SetOwner();
 }
 

--- a/TreeMod/src/HLTFwkMod.cc
+++ b/TreeMod/src/HLTFwkMod.cc
@@ -49,7 +49,7 @@ HLTFwkMod::HLTFwkMod(const char *name, const char *title) :
   fTriggers->SetOwner();
   fLabels->SetName(fHLTLabNamePub);
   fLabels->SetOwner();
-  fTrigObjArr->SetName(Form("%sCont",fObjsName.Data()));
+  fTrigObjArr->SetName(Form("%sArr", fObjsName.Data()));
   fTrigObjs->SetName(fObjsNamePub);
   fL1Algos->SetName(fL1ATabNamePub);
   fL1Algos->SetOwner();
@@ -281,6 +281,11 @@ void HLTFwkMod::SlaveBegin()
               "Could not publish HLT trigger table with name %s.", fTriggers->GetName());
     return;
   }
+  if (!PublishObj(fTrigObjArr)) {
+    SendError(kAbortAnalysis, "SlaveBegin", 
+              "Could not publish HLT trigger objects array with name %s.", fTrigObjArr->GetName());
+    return;
+  }
   if (!PublishObj(fTrigObjs)) {
     SendError(kAbortAnalysis, "SlaveBegin", 
               "Could not publish HLT trigger objects table with name %s.", fTrigObjs->GetName());
@@ -310,6 +315,7 @@ void HLTFwkMod::SlaveTerminate()
 
   RetractObj(fTriggers->GetName());
   RetractObj(fLabels->GetName());
+  RetractObj(fTrigObjArr->GetName());
   RetractObj(fTrigObjs->GetName());
   RetractObj(fL1Algos->GetName());
   RetractObj(fL1Techs->GetName());


### PR DESCRIPTION
Bugfix: Dictionary for SkimMod<PFTau> was not generated due to a missing #include.
Performance: HLTFwkMod (used in most of the analyses) was allocating memory for each trigger object for each event. Made more efficient by using TClonesArray and non-allocation new.