### PR TITLE
bugfix LinkDef of PileupEnergyDensity

### DIFF
--- a/DataTree/dict/PileupEnergyDensityColLinkDef.h
+++ b/DataTree/dict/PileupEnergyDensityColLinkDef.h
@@ -26,10 +26,7 @@
     version="[-4]" \
     source="Double32_t fRho; Double32_t fRhoHighEta; Double32_t fRhoRandom;\
             Double32_t fRhoRandomLowEta; Double32_t fRhoFixedGridAll;\
-            Double32_t fRhoFixedGridFastjetAll; Double32_t fRhoKt6CaloJets;\
-            Double32_t fRhoKt6CaloJetsCentral; Double32_t fRhoKt6PFJets;\
-            Double32_t fRhoKt6PFJetsCentralChargedPileUp; Double32_t fRhoKt6PFJetsCentralNeutral;\
-            Double32_t fRhoKt6PFJetsCentralNeutralTight;" \
+            Double32_t fRhoFixedGridFastjetAll;" \
     targetClass="mithep::PileupEnergyDensity" \
     target="fRho" \
     code="{ fRho[mithep::PileupEnergyDensity::kHighEta] = onfile.fRho;\


### PR DESCRIPTION
There was a bug in the LinkDef file for PileupEnergyDensity which was causing end-of-job crashes. The reason of the crash is deep in the ROOT I/O machinery but supposedly due to virtual object members (for fRhoKt6CaloJets and so on) being created but not properly used. This in turn was causing the cleanup in the TTree destructor to double-free.