### PR TITLE
Move external installation

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -11,3 +11,5 @@ echo "*********************"
 
 # Generate ROOT dictionaries for classes defined in this module
 $CMSSW_BASE/src/MitCommon/bin/genDict.sh MitAna/{Catalog,DataCont,DataTree,DataUtil,PhysicsMod,PhysicsUtils,TAM,TreeFiller,TreeMod,Utils,Validation}
+
+$CMSSW_BASE/src/MitAna/bin/setupExternal.sh

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -9,7 +9,7 @@ echo "*********************"
 echo " MitAna/bin/setup.sh"
 echo "*********************"
 
+$CMSSW_BASE/src/MitAna/bin/setupExternal.sh
+
 # Generate ROOT dictionaries for classes defined in this module
 $CMSSW_BASE/src/MitCommon/bin/genDict.sh MitAna/{Catalog,DataCont,DataTree,DataUtil,PhysicsMod,PhysicsUtils,TAM,TreeFiller,TreeMod,Utils,Validation}
-
-$CMSSW_BASE/src/MitAna/bin/setupExternal.sh


### PR DESCRIPTION
MitAna/bin/setup.sh will now call setupExternal.sh, which sets up scram configuration XMLs according to the available environment. The same script is called from run.sh when T2_MIT CVMFS is not available, and will work properly. The latter use case is not even supported though.

Corresponding scripts will be removed from MitPhysics. It would not be a problem if someone uses this version of MitAna but does not update MitPhysics; it merely results in same setup procedure repeated.