### PR TITLE
new module MaskCollectionMod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __init__.py
 *~
 *_LinkDefDict.*
 *_ReflexDict.*
+*.d
+*.so
+*.pcm

--- a/PhysicsMod/dict/MitAnaPhysicsModLinkDef.h
+++ b/PhysicsMod/dict/MitAnaPhysicsModLinkDef.h
@@ -9,6 +9,7 @@
 #include "MitAna/PhysicsMod/interface/TrackToPartMod.h"
 #include "MitAna/PhysicsMod/interface/MCProcessSelectionMod.h"
 #include "MitAna/PhysicsMod/interface/FastJetMod.h"
+#include "MitAna/PhysicsMod/interface/MaskCollectionMod.h"
 #endif
 
 #ifdef __CLING__
@@ -28,4 +29,5 @@
 #pragma link C++ class mithep::RunLumiSelectionMod+;
 #pragma link C++ class mithep::MCProcessSelectionMod+;
 #pragma link C++ class mithep::FastJetMod+;
+#pragma link C++ class mithep::MaskCollectionMod+;
 #endif

--- a/PhysicsMod/interface/MaskCollectionMod.h
+++ b/PhysicsMod/interface/MaskCollectionMod.h
@@ -1,0 +1,38 @@
+#ifndef MITPHYSICS_MODS_MASKCOLLECTIONMOD_H
+#define MITPHYSICS_MODS_MASKCOLLECTIONMOD_H
+
+#include "MitAna/TreeMod/interface/BaseMod.h"
+#include "MitAna/DataTree/interface/ParticleFwd.h"
+
+#include "TString.h"
+
+namespace mithep {
+
+  class MaskCollectionMod : public BaseMod {
+  public:
+    MaskCollectionMod(char const* name = "MaskCollectionMod", char const* title = "Mask collections") : BaseMod(name, title) {}
+    ~MaskCollectionMod() {}
+
+    char const* GetInputName() const { return fInputName; }
+    char const* GetMaskName() const { return fMaskName; }
+    char const* GetOutputName() const { return fOutput.GetName(); }
+
+    void SetInputName(char const* name) { fInputName = name; }
+    void SetMaskName(char const* name) { fMaskName = name; }
+    void SetOutputName(char const* name) { fOutput.SetName(name); }
+
+  private:
+    void Process() override;
+    void SlaveBegin() override;
+    void SlaveTerminate() override;
+
+    TString fInputName{};
+    TString fMaskName{};
+    ParticleOArr fOutput{};
+
+    ClassDef(MaskCollectionMod, 0)
+  };
+
+}
+
+#endif

--- a/PhysicsMod/src/MaskCollectionMod.cc
+++ b/PhysicsMod/src/MaskCollectionMod.cc
@@ -1,0 +1,40 @@
+#include "MitAna/PhysicsMod/interface/MaskCollectionMod.h"
+#include "MitAna/DataTree/interface/ParticleCol.h"
+#include "MitAna/DataCont/interface/Types.h"
+
+ClassImp(mithep::MaskCollectionMod)
+
+void
+mithep::MaskCollectionMod::Process()
+{
+  fOutput.Reset();
+
+  auto* input = GetObject<mithep::ParticleCol>(fInputName);
+  if (!input) {
+    SendError(kAbortAnalysis, "Process", "No particle collection with name " + fInputName + " found.");
+    return;
+  }
+
+  auto* mask = GetObject<mithep::NFArrBool>(fMaskName);
+  if (!mask || mask->GetEntries() != input->GetEntries()) {
+    SendError(kAbortAnalysis, "Process", "No mask with name " + fMaskName + " for collection " + fInputName + " found.");
+    return;
+  }
+
+  for (unsigned iP = 0; iP != input->GetEntries(); ++iP) {
+    if (mask->At(iP))
+      fOutput.Add(input->At(iP));
+  }
+}
+
+void
+mithep::MaskCollectionMod::SlaveBegin()
+{
+  PublishObj(&fOutput);
+}
+
+void
+mithep::MaskCollectionMod::SlaveTerminate()
+{
+  RetractObj(fOutput.GetName());
+}


### PR DESCRIPTION
Id modules can now publish an array of bools. This simple module can be used when both the filtered collection of objects and the bool array are wanted. The module takes an input particle collection and the bool array produced from it, and filters out the "failing" objects.