### PR TITLE
adding option to dynamically skip HLT when data is not present

### DIFF
--- a/DataCont/interface/RefArray.h
+++ b/DataCont/interface/RefArray.h
@@ -158,19 +158,19 @@ TObject *mithep::RefArray<ArrayElement>::GetObject(UInt_t idx) const
   TProcessID *pid = GetPID(idx); 
   
   if (!pid) {
-    Fatal("GetObject","Process id pointer is null!");
+    Fatal(TString::Format("RefArray<%s>::GetObject", ArrayElement::Class()->GetName()),"Process id pointer is null!");
     return 0;
   }
 
   if (!TProcessID::IsValid(pid)) {
-    Fatal("GetObject","Process id is invalid!");
+    Fatal(TString::Format("RefArray<%s>::GetObject", ArrayElement::Class()->GetName()), "Process id is invalid!");
     return 0;
   }
 
   UInt_t uid = GetUID(idx);
   TObject *obj = RefResolver::GetObjectWithID(uid,pid);
   if (!obj) {
-    Fatal("RefArray::GetObject","Null pointer for filled element!");
+    Fatal(TString::Format("RefArray<%s>::GetObject", ArrayElement::Class()->GetName()), "Null pointer for filled element!");
   }
   return obj;
 }

--- a/TreeMod/interface/Analysis.h
+++ b/TreeMod/interface/Analysis.h
@@ -97,11 +97,12 @@ namespace mithep
       void                      SetRunTreeName(const char *n)       { fRunTreeName    = n;        }
       void                      SetSkipFirstNEvents(Long64_t n)     { fSkipNEvents    = n;        }
       void                      SetSuperModule(TAModule *mod);
-      void                      SetTreeName(const char *name)       { fTreeName       = name;     }
-      void                      SetUseHLT(Bool_t hlt)               { fUseHLT         = hlt;      }
-      void                      SetUseMC(Bool_t mc)                 { fUseMC          = mc;       }
-      void                      SetUseProof(Bool_t up)              { fUseProof       = up;       }
-      void                      SetUseCacher(Int_t i)               { fUseCacher      = i;        }
+      void                      SetTreeName(const char *name)       { fTreeName  = name;          }
+      void                      SetUseHLT(Bool_t hlt)               { fUseHLT    = hlt ? 1 : 0;   }
+      void                      SetAllowNoHLTTree(Bool_t allow)     { fUseHLT    = allow ? 2 : 1; }
+      void                      SetUseMC(Bool_t mc)                 { fUseMC     = mc;            }
+      void                      SetUseProof(Bool_t up)              { fUseProof  = up;            }
+      void                      SetUseCacher(Int_t i)               { fUseCacher = i;             }
       void                      Terminate();
 
       void                      PrintModuleTree() const; // for debugging
@@ -124,7 +125,7 @@ namespace mithep
 
       Bool_t                    fUseProof;        //=true if PROOF is to be used (def=0)
       Bool_t                    fUseCacher;       //=1 use file caching (def=0)
-      Bool_t                    fUseHLT;          //=true if HLTFwkMod is to be used (def=true)
+      UInt_t                    fUseHLT;          //=1 if HLTFwkMod is to be used, 2 to process input with no HLT info (def=1)
       Bool_t                    fUseMC;           //=true if MCFwkMod is to be used (def=false)
       Bool_t                    fHierarchy;       //=true if module hierachy to be stored (def=1)
       Bool_t                    fDoProxy;         //=true if TRef branch autoload is used (def=0)

--- a/TreeMod/interface/HLTFwkMod.h
+++ b/TreeMod/interface/HLTFwkMod.h
@@ -15,69 +15,78 @@
 #include <string>
 #include <TString.h>
 #include "MitAna/TreeMod/interface/BaseMod.h" 
-#include "MitAna/DataTree/interface/TriggerObjectBaseFwd.h"
 #include "MitAna/DataTree/interface/TriggerObjectFwd.h"
-#include "MitAna/DataTree/interface/TriggerObjectRelFwd.h"
 #include "MitAna/DataTree/interface/TriggerTable.h"
 #include "MitAna/DataTree/interface/TriggerObjectsTable.h"
+#include "MitAna/DataTree/interface/Names.h"
 
 namespace mithep 
 {
   class HLTFwkMod : public BaseMod {
-    public:
-      HLTFwkMod(const char *name="HLTFwkMod", const char *title="HLT framework module");
-      ~HLTFwkMod();
+  public:
+    HLTFwkMod(const char *name="HLTFwkMod", const char *title="HLT framework module");
+    ~HLTFwkMod();
 
-      const char                 *L1ATabNamePub()  const { return fL1Algos->GetName(); }
-      const char                 *L1TTabNamePub()  const { return fL1Techs->GetName(); }
-      const char                 *HLTLabName()     const { return fHLTLabName;    }
-      const char                 *HLTLabNamePub()  const { return fLabels->GetName(); }
-      const char                 *HLTObjsName()    const { return fObjsName;      }
-      const char                 *HLTObjArrNamePub() const { return fTrigObjArr->GetName(); }
-      const char                 *HLTObjsNamePub() const { return fTrigObjs->GetName(); }
-      const char                 *HLTTabName()     const { return fHLTTabName;    }
-      const char                 *HLTTabNamePub()  const { return fTriggers->GetName(); }
-      const char                 *HLTTreeName()    const { return fHLTTreeName;   }
-      void                        SetL1ATabName(const char *n)     { fL1Algos->SetName(n); }
-      void                        SetL1TTabName(const char *n)     { fL1Techs->SetName(n); }
-      void                        SetHLTLabName(const char *n)     { fHLTLabName    = n; }
-      void                        SetHLTLabNamePub(const char *n)  { fLabels->SetName(n); }
-      void                        SetHLTObjsName(const char *n)    { fObjsName      = n; }
-      void                        SetHLTObjArrNamePub(const char *n) { fTrigObjArr->SetName(n); }
-      void                        SetHLTObjsNamePub(const char *n) { fTrigObjs->SetName(n); }
-      void                        SetHLTTabName(const char *n)     { fHLTTabName    = n; }
-      void                        SetHLTTabNamePub(const char *n)  { fTriggers->SetName(n); }
-      void                        SetHLTTreeName(const char *n)    { fHLTTreeName   = n; }
+    const char* L1ATabNamePub() const    { return fL1Algos.GetName(); }
+    const char* L1TTabNamePub() const    { return fL1Techs.GetName(); }
+    const char* HLTLabName() const       { return fHLTLabName;    }
+    const char* HLTLabNamePub() const    { return fLabels.GetName(); }
+    const char* HLTObjsName() const      { return fObjsName;      }
+    const char* HLTObjArrNamePub() const { return fTrigObjArr.GetName(); }
+    const char* HLTObjsNamePub() const   { return fTrigObjs.GetName(); }
+    const char* HLTTabName() const       { return fHLTTabName;    }
+    const char* HLTTabNamePub() const    { return fTriggers.GetName(); }
+    const char* HLTTreeName() const      { return fHLTTreeName;   }
 
-    protected:
-      void                        BeginRun();
-      Bool_t                      LoadTriggerTable();
-      Bool_t                      Notify();
-      void                        Process();
-      void                        SlaveBegin();
-      void                        SlaveTerminate();
+    void SetL1ATabName(const char *n)       { fL1Algos.SetName(n); }
+    void SetL1TTabName(const char *n)       { fL1Techs.SetName(n); }
+    void SetHLTLabName(const char *n)       { fHLTLabName    = n; }
+    void SetHLTLabNamePub(const char *n)    { fLabels.SetName(n); }
+    void SetHLTObjsName(const char *n)      { fObjsName      = n; }
+    void SetHLTObjArrNamePub(const char *n) { fTrigObjArr.SetName(n); }
+    void SetHLTObjsNamePub(const char *n)   { fTrigObjs.SetName(n); }
+    void SetHLTTabName(const char *n)       { fHLTTabName    = n; }
+    void SetHLTTabNamePub(const char *n)    { fTriggers.SetName(n); }
+    void SetHLTTreeName(const char *n)      { fHLTTreeName   = n; }
 
-      TString                     fHLTTreeName;   //HLT tree name
-      TString                     fHLTTabName;    //HLT trigger names branch name
-      TString                     fHLTLabName;    //HLT module labels branch name
-      TString                     fObjsName;      //trigger objects branch name
-      TString                     fRelsName;      //trigger to objects relation branch name
-      const UInt_t                fNMaxTriggers;  //maximum number of triggers
-      const TriggerObjectBaseArr *fObjs;          //!trigger objects branch
-      const TriggerObjectRelArr  *fRels;          //!trigger to objects relation branch
-      Bool_t                      fReload;        //!=true then reload/rebuild tables
-      TTree                      *fHLTTree;       //!HLT tree in current file
-      std::vector<std::string>   *fHLTTab;        //!HLT trigger names
-      std::vector<std::string>   *fHLTLab;        //!HLT module labels
-      Int_t                       fCurEnt;        //!current entry in HLT tree (-2 for unset)
-      TriggerTable               *fTriggers;      //!exported published HLT trigger table
-      TriggerTable               *fLabels;        //!exported published HLT module label table
-      TriggerObjectArr           *fTrigObjArr;    //!buffer of published HLT trigger objects
-      TriggerObjectsTable        *fTrigObjs;      //!exported published HLT trigger objects table
-      TriggerTable               *fL1Algos;       //!exported published L1 algorithm triggers table
-      TriggerTable               *fL1Techs;       //!exported published L1 technical triggers table
+    Bool_t GetAbortIfNoHLTTree() const   { return fAbortIfNoHLTTree; }
+    void   SetAbortIfNoHLTTree(Bool_t a) { fAbortIfNoHLTTree = a; }
 
-      friend class OutputMod;
+    Bool_t HasData() const { return fHLTTree != 0; }
+
+  protected:
+    Bool_t LoadTriggerTable();
+    void   BeginRun() override;
+    Bool_t Notify() override;
+    void   Process() override;
+    void   SlaveBegin() override;
+    void   SlaveTerminate() override;
+
+    TString fHLTTreeName{Names::gkHltTreeName}; //HLT tree name
+    TString fHLTTabName{Names::gkHltTableBrn};  //HLT trigger names branch name
+    TString fHLTLabName{Names::gkHltLabelBrn};  //HLT module labels branch name
+    TString fObjsName{Names::gkHltObjBrn};      //trigger objects branch name
+    TString fRelsName;                          //trigger to objects relation branch name
+
+    // inputs
+    Bool_t                    fReload{kFALSE};        //!=true then reload/rebuild tables
+    TTree*                    fHLTTree = 0;       //!HLT tree in current file
+    std::vector<std::string>* fHLTTab = 0;        //!HLT trigger names
+    std::vector<std::string>* fHLTLab = 0;        //!HLT module labels
+    Int_t                     fCurEnt{-2};        //!current entry in HLT tree (-2 for unset)
+
+    // outputs
+    const UInt_t        fNMaxTriggers{1024};  //maximum number of triggers
+    TriggerTable        fTriggers{Int_t(fNMaxTriggers)};  //!exported published HLT trigger table
+    TriggerTable        fLabels{Int_t(fNMaxTriggers) * 16}; //!exported published HLT module label table
+    TriggerObjectArr    fTrigObjArr{};    //!buffer of published HLT trigger objects
+    TriggerObjectsTable fTrigObjs;      //!exported published HLT trigger objects table
+    TriggerTable        fL1Algos{Int_t(fNMaxTriggers)}; //!exported published L1 algorithm triggers table
+    TriggerTable        fL1Techs{Int_t(fNMaxTriggers)}; //!exported published L1 technical triggers table
+
+    Bool_t fAbortIfNoHLTTree = kTRUE;
+
+    friend class OutputMod;
 
     ClassDef(HLTFwkMod, 1) // HLT framework TAM module
   };

--- a/TreeMod/src/Analysis.cc
+++ b/TreeMod/src/Analysis.cc
@@ -32,7 +32,7 @@ using namespace mithep;
 Analysis::Analysis(Bool_t useproof) :
   fUseProof(useproof),
   fUseCacher(0),
-  fUseHLT(kTRUE),
+  fUseHLT(1),
   fUseMC(kFALSE),
   fHierarchy(kTRUE),
   fDoProxy(kFALSE),
@@ -457,10 +457,12 @@ Bool_t Analysis::Init()
 
   // create our HLT framework module
   HLTFwkMod *hltmod = 0;
-  if (fUseHLT) {
+  if (fUseHLT > 0) {
     hltmod = new HLTFwkMod;
     hltmod->SetHLTObjsName(GetHLTObjsName());
     hltmod->SetHLTTreeName(GetHLTTreeName());
+    if (fUseHLT == 2)
+      hltmod->SetAbortIfNoHLTTree(false);
     fDeleteList->Add(hltmod);
   }
 

--- a/TreeMod/src/BaseMod.cc
+++ b/TreeMod/src/BaseMod.cc
@@ -70,8 +70,12 @@ Bool_t BaseMod::HasHLTInfo() const
 { 
   // Check if HLT framework module is in list of modules. 
 
-  if (fHltFwkMod) 
-    return kTRUE;
+  if (fHltFwkMod) {
+    if (fHltFwkMod->HasData())
+      return kTRUE;
+    else
+      return kFALSE;
+  }
 
   if (!GetSelector() || !GetSelector()->GetTopModule()) 
     return kFALSE;
@@ -81,7 +85,7 @@ Bool_t BaseMod::HasHLTInfo() const
     return kFALSE;
 
   fHltFwkMod = dynamic_cast<const HLTFwkMod*>(tasks->FindObject(fHltFwkModName));
-  if (fHltFwkMod)
+  if (fHltFwkMod && fHltFwkMod->HasData())
     return kTRUE;
 
   return kFALSE;


### PR DESCRIPTION
In order to have a macro that can run on normal files and private MC files that lack HLT information, switches are added to the HLTMod and HLTFwkMod to allow skipping processing if no HLT data is there. This turned out to be a bigger surgery than initially anticipated since HLTFwkMod is hidden in Analysis.