### PR TITLE
solved 'empty-tree' problem by requiring OutputMod to be a supermodule

### DIFF
--- a/TreeMod/interface/OutputMod.h
+++ b/TreeMod/interface/OutputMod.h
@@ -1,6 +1,4 @@
 //--------------------------------------------------------------------------------------------------
-// $Id: OutputMod.h,v 1.12 2009/07/17 20:47:42 loizides Exp $
-//
 // OutputMod
 //
 // This TAM module writes selected events and selected branches to a new output file. 
@@ -48,6 +46,7 @@ namespace mithep
       void                        SetUseBrDep(Bool_t b)         { fUseBrDep   = b; }
       void                        SetCheckTamBr(Bool_t b)       { fCheckTamBr = b; }
       void                        SetKeepTamBr(Bool_t b)        { fKeepTamBr  = b; }
+      void                        AddCondition(BaseMod* m)      { fCondition.push_back(m); }
 
     protected:
       void                        BeginRun();
@@ -111,6 +110,7 @@ namespace mithep
       Long64_t                    fLastWrittenEvt;  //!entry of last written event
       Long64_t                    fLastSeenEvt;     //!entry of last seen event
       Long64_t                    fCounter;         //!count number of events
+      std::vector<BaseMod*>       fCondition;       //write when any of the modules is active (if empty, always write)
 
       friend class Selector;
 


### PR DESCRIPTION
OutputMod was indeed creating branches at the first event to be processed, and for a good reason. The pointers to the objects filled in the branches are available only after LoadBranch, which is only possible in Process() function. If a null pointer is passed to the tree, ROOT will automatically allocate a new object, and the current implementation of TreeWriter in fact forbids a null pointer to be passed for this reason.
We can work around this problem and still be able to write skims by requiring the OutputMod to be always a supermod (therefore OutputMod::Process is guaranteed to be reached) but adding "conditions" = list of modules at least one of which must be active (i.e. not in an aborted path). This is very similar to the CMSSW OutputModule implementation, where output module is placed in the EndPath, which is always processed, and is given a list of paths that define the event acceptance.