### PR TITLE
skip mode was not the right implementation

### DIFF
--- a/TreeMod/interface/HLTMod.h
+++ b/TreeMod/interface/HLTMod.h
@@ -56,8 +56,8 @@ namespace mithep
     Int_t       GetNFailed() const      { return fNFailed;       }
 
     void AddTrigger(const char *expr, UInt_t firstRun = 0, UInt_t lastRun = 0);
-    void SetAbortIfNotAccepted(Bool_t b) { fSkipMode = (b ? 0 : 1); }
-    void SetAbortIfNoData(Bool_t b)      { fSkipMode = (b ? (fSkipMode < 2 ? fSkipMode : 0) : 2); }
+    void SetAbortIfNotAccepted(Bool_t b) { fAbortIfNotAccepted = b; }
+    void SetAbortIfNoData(Bool_t b)      { fAbortIfNoData = b; }
     void SetBitsName(const char *n)      { fBitsName = n; }
     void SetIgnoreBits(Bool_t b)         { fIgnoreBits = b; }
     void SetInputName(const char *n)     { fMyObjsNamePub = n; }
@@ -78,7 +78,8 @@ namespace mithep
     typedef std::pair<TString, RunRange> TriggerNameWithValidity;
     typedef std::vector<TriggerNameWithValidity> TriggerNames;
 
-    Int_t        fSkipMode = 0;  //=0->Skip if triggers did not fire, 1->Keep running, 2->Keep running even if HLT data not present
+    Bool_t       fAbortIfNotAccepted{kTRUE};
+    Bool_t       fAbortIfNoData{kTRUE}; //set to false for e.g. private MC with no HLT info
     Bool_t       fPrintTable{kFALSE};    //=true then print HLT trigger table in BeginRun
     Bool_t       fIgnoreBits{kFALSE};    //=true then try to get trigger objects (def=0)
     EObjMode     fObjMode{kHlt};       //defines which objects to get (def=kHlt)
@@ -89,6 +90,8 @@ namespace mithep
     Int_t fNEvents{0};       //!number of processed events
     Int_t fNAccepted{0};     //!number of accepted events
     Int_t fNFailed{0};       //!number of failed events
+
+    Bool_t fSkipModule{kFALSE}; //set to true when HLTInfo is not found in SlaveBegin
 
     std::vector<BitMask1024>   fTrigBitsAnd{};   //!trigger bits used in mask
     std::vector<BitMask1024>   fTrigBitsCmp{};   //!trigger bits used for comparison

--- a/TreeMod/src/BaseMod.cc
+++ b/TreeMod/src/BaseMod.cc
@@ -70,12 +70,8 @@ Bool_t BaseMod::HasHLTInfo() const
 { 
   // Check if HLT framework module is in list of modules. 
 
-  if (fHltFwkMod) {
-    if (fHltFwkMod->HasData())
-      return kTRUE;
-    else
-      return kFALSE;
-  }
+  if (fHltFwkMod)
+    return kTRUE;
 
   if (!GetSelector() || !GetSelector()->GetTopModule()) 
     return kFALSE;
@@ -85,7 +81,7 @@ Bool_t BaseMod::HasHLTInfo() const
     return kFALSE;
 
   fHltFwkMod = dynamic_cast<const HLTFwkMod*>(tasks->FindObject(fHltFwkModName));
-  if (fHltFwkMod && fHltFwkMod->HasData())
+  if (fHltFwkMod)
     return kTRUE;
 
   return kFALSE;

--- a/TreeMod/src/HLTMod.cc
+++ b/TreeMod/src/HLTMod.cc
@@ -1,4 +1,5 @@
 #include "MitAna/TreeMod/interface/HLTMod.h"
+#include "MitAna/TreeMod/interface/HLTFwkMod.h"
 #include "MitAna/DataTree/interface/TriggerName.h"
 #include "MitAna/DataTree/interface/TriggerMask.h"
 #include "MitAna/DataTree/interface/TriggerObject.h"
@@ -83,6 +84,21 @@ void HLTMod::AddTrigObjs(TriggerObjectOArr& myTrgObjs, BitMask1024& bitsDone, UI
 void HLTMod::BeginRun()
 {
   // Get HLT tree and set branches. Compute bitmasks to be used when comparing to the HLT bits.
+
+  if (fSkipModule)
+    return;
+
+  // HLTFwkMod must have the tree data by now
+  if (!GetHltFwkMod()->HasData()) {
+    if (fAbortIfNoData) {
+      SendError(kAbortAnalysis, "BeginRun", "HLT info not available.");
+      return;
+    }
+    else {
+      fSkipModule = true; // skip all subsequent functions of this module
+      return;
+    }
+  }
 
   if (fSkipModule)
     return;

--- a/TreeMod/src/HLTMod.cc
+++ b/TreeMod/src/HLTMod.cc
@@ -84,7 +84,7 @@ void HLTMod::BeginRun()
 {
   // Get HLT tree and set branches. Compute bitmasks to be used when comparing to the HLT bits.
 
-  if (fSkipMode == -2)
+  if (fSkipModule)
     return;
 
   fTrigBitsAnd.clear();
@@ -172,9 +172,9 @@ void HLTMod::Process()
 {
   // Process trigger bits for this event. If trigger bits pass the given bit mask, then obtain
   // and publish the corresponding trigger objects. If OnAccepted or OnFailed is implemented
-  // in a derived class, call it. Do not stop processing this event, if fSkipMode > 0.
+  // in a derived class, call it.
 
-  if (fSkipMode == -2)
+  if (fSkipModule)
     return;
 
   ++fNEvents; 
@@ -202,7 +202,7 @@ void HLTMod::Process()
     ++fNFailed;
     OnFailed();
     delete myTrgObjs;
-    if (fSkipMode == 0)
+    if (fAbortIfNotAccepted)
       SkipEvent(); // abort processing of this event by sub-modules
 
     return;
@@ -230,12 +230,12 @@ void HLTMod::SlaveBegin()
   // Request trigger bit branch and obtain trigger table and objects.
 
   if (!HasHLTInfo()) {
-    if (fSkipMode < 2) {
+    if (fAbortIfNoData) {
       SendError(kAbortAnalysis, "SlaveBegin", "HLT info not available.");
       return;
     }
     else {
-      fSkipMode = -2; // skip all subsequent functions of this module
+      fSkipModule = true; // skip all subsequent functions of this module
       return;
     }
   }


### PR DESCRIPTION
Aborting when there is no data and aborting when trigger did not fire are not mutually exclusive. Need two independent booleans.