### PR TITLE
Adding ValidFraction, NMatchedStations, Chi2LocalPosition, Chi2LocalMomentum

### DIFF
--- a/DataTree/interface/MuonQuality.h
+++ b/DataTree/interface/MuonQuality.h
@@ -1,6 +1,4 @@
 //--------------------------------------------------------------------------------------------------
-// $Id $
-//
 // MuonQuality
 //
 // Wrapper for BitMask storing the Muon Quality flags. We save information on exactly which 
@@ -21,29 +19,29 @@ namespace mithep
   {
     public:
       enum MuonSelectionType { //taken from DataFormats/MuonReco/interface/MuonSelectors.h
-        All = 0,                      //dummy options - always true
-        AllGlobalMuons = 1,           //checks isGlobalMuon flag
-        AllStandAloneMuons = 2,       //checks isStandAloneMuon flag
-        AllTrackerMuons = 3,          //checks isTrackerMuon flag
-        TrackerMuonArbitrated = 4,    //resolve ambiguity of sharing segments
-        AllArbitrated = 5,            //all muons with the tracker muon arbitrated
-        GlobalMuonPromptTight = 6,    //global muons with tighter fit requirements
-        TMLastStationLoose = 7,       //penetration depth loose selector
-        TMLastStationTight = 8,       //penetration depth tight selector
-        TM2DCompatibilityLoose = 9,   //likelihood based loose selector
-        TM2DCompatibilityTight = 10,  //likelihood based tight selector
-        TMOneStationLoose = 11,       //require one well matched segment
-        TMOneStationTight = 12,       //require one well matched segment
-        TMLastStationOptimizedLowPtLoose = 13, //combination of TMLastStation and TMOneStation
-        TMLastStationOptimizedLowPtTight = 14, //combination of TMLastStation and TMOneStation
-        GMTkChiCompatibility = 15,    //require tk stub have good chi2 relative to glb track
-        GMStaChiCompatibility = 16,   //require sta stub have good chi2 compatibility 
+        All,                      //dummy options - always true
+        AllGlobalMuons,           //checks isGlobalMuon flag
+        AllStandAloneMuons,       //checks isStandAloneMuon flag
+        AllTrackerMuons,          //checks isTrackerMuon flag
+        TrackerMuonArbitrated,    //resolve ambiguity of sharing segments
+        AllArbitrated,            //all muons with the tracker muon arbitrated
+        GlobalMuonPromptTight,    //global muons with tighter fit requirements
+        TMLastStationLoose,       //penetration depth loose selector
+        TMLastStationTight,       //penetration depth tight selector
+        TM2DCompatibilityLoose,   //likelihood based loose selector
+        TM2DCompatibilityTight,  //likelihood based tight selector
+        TMOneStationLoose,       //require one well matched segment
+        TMOneStationTight,       //require one well matched segment
+        TMLastStationOptimizedLowPtLoose, //combination of TMLastStation and TMOneStation
+        TMLastStationOptimizedLowPtTight, //combination of TMLastStation and TMOneStation
+        GMTkChiCompatibility,    //require tk stub have good chi2 relative to glb track
+        GMStaChiCompatibility,   //require sta stub have good chi2 compatibility 
                                       //relative to glb track
-        GMTkKinkTight = 17,           //require a small kink value in the tracker stub
-        TMLastStationAngLoose = 18,   //TMLastStationLoose with additional angular cuts
-        TMLastStationAngTight = 19,   //TMLastStationTight with additional angular cuts
-        TMOneStationAngLoose = 20,    //TMOneStationLoose with additional angular cuts
-        TMOneStationAngTight = 21,    //TMOneStationTight with additional angular cuts
+        GMTkKinkTight,           //require a small kink value in the tracker stub
+        TMLastStationAngLoose,   //TMLastStationLoose with additional angular cuts
+        TMLastStationAngTight,   //TMLastStationTight with additional angular cuts
+        TMOneStationAngLoose,    //TMOneStationLoose with additional angular cuts
+        TMOneStationAngTight,    //TMOneStationTight with additional angular cuts
         //The two algorithms that follow are identical to what were known as
         //TMLastStationOptimizedLowPt* (sans the Barrel) as late as revision
         //1.7 of this file. The names were changed because indeed the low pt
@@ -51,10 +49,10 @@ namespace mithep
         //ectors above are more efficient at low pt in the endcaps, which is
         //what we feel is more suggestive of the algorithm name. This will be
         //less confusing for future generations of CMS members, I hope...
-        TMLastStationOptimizedBarrelLowPtLoose = 22, //combination of TMLastStation and TMOneStation 
-                                                     //but with low pT optimization in barrel only
-        TMLastStationOptimizedBarrelLowPtTight = 23  //combination of TMLastStation and TMOneStation 
-                                                     //but with low pT optimization in barrel only
+        TMLastStationOptimizedBarrelLowPtLoose, //combination of TMLastStation and TMOneStation 
+                                                //but with low pT optimization in barrel only
+        TMLastStationOptimizedBarrelLowPtTight  //combination of TMLastStation and TMOneStation 
+                                                //but with low pT optimization in barrel only
       };
 
       MuonQuality() {}


### PR DESCRIPTION
As pointed out by Dylan. We were lacking variables that cannot be / are difficult to calculate on the fly but are used for standard muon Id.