### PR TITLE
Hltfwkmod bugfix + OutputMod updates

### DIFF
--- a/TreeMod/interface/Analysis.h
+++ b/TreeMod/interface/Analysis.h
@@ -33,14 +33,16 @@ class TChain;
 class TDSet;
 class TString;
 class TAModule;
-class TAMSelector;
 class TAMVirtualLoader;
 class TObjArray;
 class TProof;
 
 namespace mithep 
 {
+  class Selector;
   class Dataset;
+  class OutputMod;
+
   class Analysis : public TObject 
   {
     public:
@@ -54,6 +56,7 @@ namespace mithep
       void                      AddPackage(const char *name);
       void                      AddPackages(TList *list);
       void                      AddSuperModule(TAModule *mod);
+      void                      AddOutputMod(OutputMod* mod);
       const char               *GetAllEvtTreeName()           const { return fAllEvtTreeName;     }
       const char               *GetAllEvtHdrBrn()             const { return fAllEvtHdrBrn;       }
       const char               *GetAnaOutputName()            const { return fAnaOutput;          }
@@ -138,7 +141,7 @@ namespace mithep
       TList                    *fPackages;        //list of package names for PROOF upload
       TList                    *fLoaders;         //list of loaders
       TList                    *fSuperMods;       //top level TAM module(s) (not owned)
-      TAMSelector              *fSelector;        //selector for non-PROOF usage
+      Selector                 *fSelector;        //selector for non-PROOF usage
       TChain                   *fChain;           //trees or friend trees for non-PROOF usage
       TDSet                    *fSet;             //set of trees or friend trees for PROOF usage
       TList                    *fDeleteList;      //list of objects to be deleted on Terminate()

--- a/TreeMod/interface/BaseMod.h
+++ b/TreeMod/interface/BaseMod.h
@@ -59,7 +59,7 @@ namespace mithep
     const MCRunInfo            *GetMCRunInfo()        const { return GetSel()->GetMCRunInfo();   }
     const TriggerTable         *GetTriggerTable(ETrigType t)    const;
     const Selector             *GetSel()              const;
-    Bool_t                      HasHLTInfo()          const;
+    Bool_t                      HasHLTInfo()          const; // true only means HLTFwkMod is loaded to the Selector
     void                        IncNEventsProcessed()       { ++fNEventsProc;                    }
     template <class T> T*       GetObject(char const* name, Bool_t warn = kTRUE);
     template <class T> Bool_t   LoadEventObject(char const* name, T const*&, Bool_t warn = kTRUE);

--- a/TreeMod/interface/Selector.h
+++ b/TreeMod/interface/Selector.h
@@ -42,6 +42,7 @@ namespace mithep {
     const char*          GetMCRunInfoName()         const { return fMCRunInfoName;         }
     const RunInfo*       GetRunInfo()               const { return fRunInfo;               }
     const MCRunInfo*     GetMCRunInfo()             const { return fMCRunInfo;             }
+    const TList&         GetOutputMods()            const { return fOutputMods;            }
     template <class T>
     T*                   GetObject(char const* name, Bool_t warn);
     Bool_t               ValidRunInfo()             const;
@@ -56,6 +57,7 @@ namespace mithep {
     void                 SetRunInfoName(const char* n)    { fRunInfoName    = n; }
     void                 SetMCRunInfoName(const char* n)  { fMCRunInfoName  = n; }
     void                 SetRunTreeName(const char* n)    { fRunTreeName    = n; }
+    void                 AddOutputMod(OutputMod*);
 
     class ObjInfo : public TNamed {
     // Helper class to associate an object name with its source type and class type.
@@ -138,8 +140,6 @@ namespace mithep {
     THashTable           fObjInfoStore;   //!single-point pointer store for GetObject function
 
   private:
-    void                 SearchOutputMods(const TAModule* mod);
-
     friend class OutputMod;
 
     ClassDef(Selector, 1) // Customized selector class

--- a/TreeMod/src/AnaFwkMod.cc
+++ b/TreeMod/src/AnaFwkMod.cc
@@ -63,7 +63,7 @@ void AnaFwkMod::BeginRun()
 
     // get all event header tree
     fAllHeadTree = dynamic_cast<TTree*>(file->Get(fAllHeadTreeName));
-    if (! fAllHeadTree) {
+    if (!fAllHeadTree) {
       MDB(kTreeIO, 3)
 	Info("BeginRun",
 	     "Cannot find tree '%s' in file '%s'",fAllHeadTreeName.Data(),file->GetName());

--- a/TreeMod/src/HLTFwkMod.cc
+++ b/TreeMod/src/HLTFwkMod.cc
@@ -204,6 +204,9 @@ void HLTFwkMod::Process()
 {
   // Read trigger objects and relation branch and fill our object table.
 
+  if (!fHLTTree)
+    return;
+
   fTrigObjs.Clear();
   fTrigObjArr.Reset();
 

--- a/TreeMod/src/HLTMod.cc
+++ b/TreeMod/src/HLTMod.cc
@@ -85,9 +85,6 @@ void HLTMod::BeginRun()
 {
   // Get HLT tree and set branches. Compute bitmasks to be used when comparing to the HLT bits.
 
-  if (fSkipModule)
-    return;
-
   // HLTFwkMod must have the tree data by now
   if (!GetHltFwkMod()->HasData()) {
     if (fAbortIfNoData) {
@@ -99,9 +96,6 @@ void HLTMod::BeginRun()
       return;
     }
   }
-
-  if (fSkipModule)
-    return;
 
   fTrigBitsAnd.clear();
   fTrigBitsCmp.clear();
@@ -246,14 +240,8 @@ void HLTMod::SlaveBegin()
   // Request trigger bit branch and obtain trigger table and objects.
 
   if (!HasHLTInfo()) {
-    if (fAbortIfNoData) {
-      SendError(kAbortAnalysis, "SlaveBegin", "HLT info not available.");
-      return;
-    }
-    else {
-      fSkipModule = true; // skip all subsequent functions of this module
-      return;
-    }
+    SendError(kAbortAnalysis, "SlaveBegin", "HLTFwkMod not available.");
+    return;
   }
 
   fTriggers = GetHLTTable();
@@ -262,7 +250,7 @@ void HLTMod::SlaveBegin()
     return;
   }
   fTrigObjs = GetHLTObjectsTable();
-  if (! fTrigObjs) {
+  if (!fTrigObjs) {
     SendError(kAbortAnalysis, "SlaveBegin", "Could not get HLT trigger objects table.");
     return;
   }


### PR DESCRIPTION
. Further fixes on HLT-related modules to allow running on files with no HLT data.
. Fixed bug in OutputMod where AllEvent header was filled before updating the run tree entry index of the current header
. More consistent handling of OutputMod at the Analysis level (new function AddOutputMod which inserts an output module to the end of the SuperModules list)