### PR TITLE
Moved substructure info from FatJet to XlFatJet

### DIFF
--- a/DataTree/interface/FatJet.h
+++ b/DataTree/interface/FatJet.h
@@ -83,7 +83,7 @@ namespace mithep {
     float Tau1IVF() const               { return fTau1IVF; }
     float Tau2IVF() const               { return fTau2IVF; }
     float Tau3IVF() const               { return fTau3IVF; }
-    Vect3    GetTauIVFAxis(UInt_t i) const { return fTauIVFAxes.at(i); }
+    Vect3    const & GetTauIVFAxis(UInt_t i) const { return fTauIVFAxes.at(i); }
     float tauDot() const                { return fTauDot; }
     float zRatio() const                { return fZRatio; }
 
@@ -121,7 +121,7 @@ namespace mithep {
     float         fTau3IVF{-1.};         //3-subjettiness
     std::vector<Vect3> fTauIVFAxes{};
 
-    std::vector<float> fSubjetBtags;
+    std::vector<float> fSubjetBtags; // ordered by decreasing subjet pT
 
 
     // IVF variables

--- a/DataTree/interface/FatJet.h
+++ b/DataTree/interface/FatJet.h
@@ -20,57 +20,57 @@ namespace mithep {
   class FatJet : public PFJet {
   public:
     struct TrackData { // per track
-      double length;
-      double dist;
-      double dxy;
-      double dz;
-      double IP2D;
-      double IP2Dsig;
-      double IP;
-      double IPsig;
-      double IP2Derr;
-      double IPerr;
-      double prob;
-      double pt;
-      double eta;
-      double phi;
-      double PVWeight;
-      double SVWeight;
+      float length;
+      float dist;
+      float dxy;
+      float dz;
+      float IP2D;
+      float IP2Dsig;
+      float IP;
+      float IPsig;
+      float IP2Derr;
+      float IPerr;
+      float prob;
+      float pt;
+      float eta;
+      float phi;
+      float PVWeight;
+      float SVWeight;
       int PV;
       int fromSV;
       int SV;
     };
 
     struct SVData { // per SV
-      double flight;
-      double flightErr;
-      double deltaRJet;
-      double deltaRSumJet;
-      double deltaRSumDir;
-      double flight2D;
-      double flight2DErr;
-      double totCharge;
-      double vtxDistJetAxis;
+      float flight;
+      float flightErr;
+      float deltaRJet;
+      float deltaRSumJet;
+      float deltaRSumDir;
+      float flight2D;
+      float flight2DErr;
+      float totCharge;
+      float vtxDistJetAxis;
       int nTrk;
-      double mass;
-      double energyRatio;
-      double pt;
-      double eta;
-      double phi;
-      double dirX;
-      double dirY;
-      double dirZ;
+      float mass;
+      float energyRatio;
+      float pt;
+      float eta;
+      float phi;
+      float dirX;
+      float dirY;
+      float dirZ;
     };
 
     struct LeptonData {
-      double pt;
-      double eta;
-      double phi;
-      double ptRel;
-      double ratio;
-      double ratioRel;
-      double IP;
-      double IP2D;
+      float pt;
+      float eta;
+      float phi;
+      float ptRel;
+      float ratio;
+      float ratioRel;
+      float IP;
+      float IP2D;
     };
 
     FatJet() : PFJet() {}

--- a/DataTree/interface/FatJet.h
+++ b/DataTree/interface/FatJet.h
@@ -79,21 +79,14 @@ namespace mithep {
 
     EObjType ObjType() const override { return kFatJet; }
 
-    Double_t Charge() const                { return fCharge; }
-    Double_t Tau1IVF() const               { return fTau1IVF; }
-    Double_t Tau2IVF() const               { return fTau2IVF; }
-    Double_t Tau3IVF() const               { return fTau3IVF; }
+    float Charge() const                { return fCharge; }
+    float Tau1IVF() const               { return fTau1IVF; }
+    float Tau2IVF() const               { return fTau2IVF; }
+    float Tau3IVF() const               { return fTau3IVF; }
     Vect3    GetTauIVFAxis(UInt_t i) const { return fTauIVFAxes.at(i); }
-    Double_t Tau1() const                  { return fTau1; }
-    Double_t Tau2() const                  { return fTau2; }
-    Double_t Tau3() const                  { return fTau3; }
-    Double_t Tau4() const                  { return fTau4; }
-    Double_t QJetVol() const               { return fQJetVol; }
-    Double_t tauDot() const                { return fTauDot; }
-    Double_t zRatio() const                { return fZRatio; }
+    float tauDot() const                { return fTauDot; }
+    float zRatio() const                { return fZRatio; }
 
-    Bool_t   HasSubJet(XlSubJet const* s, XlSubJet::ESubJetType t) const
-    { return fSubJets[t].HasObject(s); }
 
     Jet* MakeCopy() const override { return new FatJet(*this); }
 
@@ -101,74 +94,50 @@ namespace mithep {
     std::vector<SVData> const&     GetSVData() const       { return fSVData; }
     std::vector<LeptonData> const& GetMuonData() const     { return fMuonData; }
     std::vector<LeptonData> const& GetElectronData() const { return fElectronData; }
+    std::vector<float> const& GetSubJetBtags() const       { return fSubjetBtags; }
 
-    RefArray<XlSubJet> const& GetSubJets(XlSubJet::ESubJetType t) const { return fSubJets[t]; }
 
     void SetCharge()                    { fCharge  = this->GetCharge(); }
-    void SetTau1IVF(Double_t t)         { fTau1IVF        = t; }
-    void SetTau2IVF(Double_t t)         { fTau2IVF        = t; }
-    void SetTau3IVF(Double_t t)         { fTau3IVF        = t; }
+    void SetTau1IVF(float t)         { fTau1IVF        = t; }
+    void SetTau2IVF(float t)         { fTau2IVF        = t; }
+    void SetTau3IVF(float t)         { fTau3IVF        = t; }
     void AddTauIVFAxis(Vect3 p)         { fTauIVFAxes.push_back(p); }
-    void SetTau1(Double_t t)            { fTau1        = t; }
-    void SetTau2(Double_t t)            { fTau2        = t; }
-    void SetTau3(Double_t t)            { fTau3        = t; }
-    void SetTau4(Double_t t)            { fTau4        = t; }
-    void SetQJetVol(Double_t t)         { fQJetVol     = t; }
-    void SetTauDot(Double_t t)          { fTauDot = t; }
-    void SetZRatio(Double_t t)          { fZRatio = t; }
+
+    void SetTauDot(float t)          { fTauDot = t; }
+    void SetZRatio(float t)          { fZRatio = t; }
     void AddTrackData(TrackData *t)     { fTrackData.push_back(*t); }
     void AddSVData(SVData *s)           { fSVData.push_back(*s); }
     void AddMuonData(LeptonData *s)     { fMuonData.push_back(*s); }
     void AddElectronData(LeptonData *s) { fElectronData.push_back(*s); }
-    void SetPrunedP(Vect4M p)           { fPrunedP = p; }
-    void SetTrimmedP(Vect4M p)          { fTrimmedP = p; }
-    void AddSubJet(XlSubJet const*, XlSubJet::ESubJetType = XlSubJet::nSubJetTypes);
+    void AddSubJetBtag(float btag) { fSubjetBtags.push_back(btag); }
 
-    void Mark(UInt_t i=1) const override;
 
   protected:
     Double_t GetCharge() const override;
 
-    Double32_t         fCharge{0.};       //Pt-weighted jet charge
-    Double32_t         fTau1IVF{-1.};         //1-subjettiness
-    Double32_t         fTau2IVF{-1.};         //2-subjettiness
-    Double32_t         fTau3IVF{-1.};         //3-subjettiness
+    float         fCharge{0.};       //Pt-weighted jet charge
+    float         fTau1IVF{-1.};         //1-subjettiness
+    float         fTau2IVF{-1.};         //2-subjettiness
+    float         fTau3IVF{-1.};         //3-subjettiness
     std::vector<Vect3> fTauIVFAxes{};
-    Double32_t         fTau1{-1.};         //1-subjettiness
-    Double32_t         fTau2{-1.};         //2-subjettiness
-    Double32_t         fTau3{-1.};         //3-subjettiness
-    Double32_t         fTau4{-1.};         //4-subjettiness
-    Double32_t         fQJetVol{0.};      //QJets volatility
-    Double32_t         fCh{-999.};          // shower deconstruction probability
-    Vect4M             fPrunedP{};
-    Vect4M             fTrimmedP{};
 
-    RefArray<XlSubJet> fSubJets[XlSubJet::nSubJetTypes];      //sub jets in the jet
+    std::vector<float> fSubjetBtags;
+
 
     // IVF variables
-    Double32_t         fTauDot{-1.};
-    Double32_t         fZRatio{-1.};
+    float         fTauDot{-1.};
+    float         fZRatio{-1.};
     std::vector<TrackData>  fTrackData{};
     std::vector<SVData>     fSVData{};
     std::vector<LeptonData> fMuonData{};
     std::vector<LeptonData> fElectronData{};
 
-    ClassDef(FatJet, 1) // FatJet class
+    ClassDef(FatJet, 2) // FatJet class
   };
 
 }
 
-//--------------------------------------------------------------------------------------------------
-inline
-void
-mithep::FatJet::Mark(UInt_t ib) const
-{
-  // mark myself
-  mithep::DataObject::Mark(ib);
-  // mark my dependencies if they are there
-  for (auto& subjet : fSubJets)
-    subjet.Mark(ib);
-}
+
 
 //--------------------------------------------------------------------------------------------------
 inline
@@ -177,21 +146,13 @@ mithep::FatJet::GetCharge() const
 {
   // Return the sum of constituents PFCandidates weighted by their pt
 
-  Double_t charge = 0;
+  float charge = 0;
   for (UInt_t i = 0; i< NPFCands(); ++i)
     charge += PFCand(i)->Charge() * PFCand(i)->Pt();
 
   return charge / Pt();
 }
 
-inline
-void
-mithep::FatJet::AddSubJet(XlSubJet const* subjet, XlSubJet::ESubJetType type/* = XlSubJet::nSubJetTypes*/)
-{
-  if (type == XlSubJet::nSubJetTypes)
-    fSubJets[subjet->SubJetType()].Add(subjet);
-  else
-    fSubJets[type].Add(subjet);
-}
+
 
 #endif

--- a/DataTree/interface/XlFatJet.h
+++ b/DataTree/interface/XlFatJet.h
@@ -44,10 +44,10 @@ namespace mithep {
     float Tau3() const                  { return fTau3; }
     float Tau4() const                  { return fTau4; }
     float QJetVol() const               { return fQJetVol; }
-    
+
     Bool_t   HasSubJet(XlSubJet const* s, XlSubJet::ESubJetType t) const
     { return fSubJets[t].HasObject(s); }
-    
+
     RefArray<XlSubJet> const& GetSubJets(XlSubJet::ESubJetType t) const { return fSubJets[t]; }
 
     Jet* MakeCopy() const override { return new XlFatJet(*this); }
@@ -106,6 +106,7 @@ namespace mithep {
     Double32_t         fQJetVol{0.};      //QJets volatility
     Vect4M             fPrunedP{};
     Vect4M             fTrimmedP{};
+    Vect4M             fSoftDropP{};
 
     RefArray<XlSubJet> fSubJets[XlSubJet::nSubJetTypes];      //sub jets in the jet
 

--- a/DataTree/interface/XlFatJet.h
+++ b/DataTree/interface/XlFatJet.h
@@ -39,8 +39,19 @@ namespace mithep {
     Double_t PullAngle() const    { return fPullAngle; }
     Double_t chi() const          { return fChi; }
     Int_t    nMicrojets() const   { return fNMicrojets; }
+    float Tau1() const                  { return fTau1; }
+    float Tau2() const                  { return fTau2; }
+    float Tau3() const                  { return fTau3; }
+    float Tau4() const                  { return fTau4; }
+    float QJetVol() const               { return fQJetVol; }
+    
+    Bool_t   HasSubJet(XlSubJet const* s, XlSubJet::ESubJetType t) const
+    { return fSubJets[t].HasObject(s); }
+    
+    RefArray<XlSubJet> const& GetSubJets(XlSubJet::ESubJetType t) const { return fSubJets[t]; }
 
     Jet* MakeCopy() const override { return new XlFatJet(*this); }
+    void Mark(UInt_t i=1) const override;
 
     void SetQGTag(Double_t t)        { fQGTag = t; }
     void SetC2b0(Double_t t)         { fC2b0 = t; }
@@ -59,6 +70,15 @@ namespace mithep {
     void SetPullAngle(Double_t t)    { fPullAngle = t; }
     void SetChi(Double_t t)          { fChi = t; }
     void SetNMicrojets(Int_t t)      { fNMicrojets = t; }
+    void SetTau1(float t)            { fTau1        = t; }
+    void SetTau2(float t)            { fTau2        = t; }
+    void SetTau3(float t)            { fTau3        = t; }
+    void SetTau4(float t)            { fTau4        = t; }
+    void SetQJetVol(float t)         { fQJetVol     = t; }
+    void SetPrunedP(Vect4M p)           { fPrunedP = p; }
+    void SetTrimmedP(Vect4M p)          { fTrimmedP = p; }
+    void AddSubJet(XlSubJet const*, XlSubJet::ESubJetType = XlSubJet::nSubJetTypes);
+
 
   protected:
     Double32_t fQGTag{0.};        //QG tagging
@@ -79,9 +99,41 @@ namespace mithep {
     //either choose 2-prong or 3-prong subclustering!
     Double32_t fChi{-999.};          // shower deconstruction probability
     Int_t      fNMicrojets{0};
+    Double32_t         fTau1{-1.};         //1-subjettiness
+    Double32_t         fTau2{-1.};         //2-subjettiness
+    Double32_t         fTau3{-1.};         //3-subjettiness
+    Double32_t         fTau4{-1.};         //4-subjettiness
+    Double32_t         fQJetVol{0.};      //QJets volatility
+    Vect4M             fPrunedP{};
+    Vect4M             fTrimmedP{};
 
-    ClassDef(XlFatJet, 5) // XlFatJet class
+    RefArray<XlSubJet> fSubJets[XlSubJet::nSubJetTypes];      //sub jets in the jet
+
+    ClassDef(XlFatJet, 6) // XlFatJet class
   };
 
 }
+
+inline
+void
+mithep::XlFatJet::AddSubJet(XlSubJet const* subjet, XlSubJet::ESubJetType type/* = XlSubJet::nSubJetTypes*/)
+{
+  if (type == XlSubJet::nSubJetTypes)
+    fSubJets[subjet->SubJetType()].Add(subjet);
+  else
+    fSubJets[type].Add(subjet);
+}
+
+//--------------------------------------------------------------------------------------------------
+inline
+void
+mithep::XlFatJet::Mark(UInt_t ib) const
+{
+  // mark myself
+  mithep::DataObject::Mark(ib);
+  // mark my dependencies if they are there
+  for (auto& subjet : fSubJets)
+    subjet.Mark(ib);
+}
+
 #endif


### PR DESCRIPTION
Key change was moving of subjet computation/storing. Also moved some substructure floats that can be computed on top of Bambu to speed up production. Finally, all doubles are now floats.