### PR TITLE
fix runentry of allevent + MC event weight for skimmed events

### DIFF
--- a/TreeMod/src/OutputMod.cc
+++ b/TreeMod/src/OutputMod.cc
@@ -3,7 +3,7 @@
 #include "MitAna/DataTree/interface/Names.h"
 #include "MitAna/DataTree/interface/BranchTable.h"
 #include "MitAna/DataTree/interface/EventHeaderCol.h"
-#include "MitAna/DataTree/interface/PhotonCol.h"
+#include "MitAna/DataTree/interface/MCEventInfo.h"
 #include "MitAna/TreeMod/interface/TreeBranchLoader.h"
 #include "MitAna/TreeMod/interface/OutputMod.h"
 #include "MitAna/TreeMod/interface/HLTFwkMod.h"
@@ -290,8 +290,18 @@ void OutputMod::FillAllEventHeader(Bool_t isremoved)
     fAllEventHeader->SetSkimmed(eh->Skimmed()+1);
   }
   else {
-    fAllEventHeader->SetRunEntry(eh->RunEntry());
+    // isremoved == false called from Process()
+    // fEventHeader has the correct run entry of the output file
+    fAllEventHeader->SetRunEntry(fEventHeader->RunEntry());
     fAllEventHeader->SetSkimmed(eh->Skimmed());
+  }
+
+  if (eh->IsMC()) {
+    // Need to record MC event weight of the potentially skipped event
+    // Will be needed for certain NLO MC scheme where event weight can be negative
+    auto* mcInfo = GetObject<MCEventInfo>(Names::gkMCEvtInfoBrn, false);
+    if (mcInfo)
+      fAllEventHeader->SetWeight(mcInfo->Weight());
   }
 
   fAllTree->Fill();


### PR DESCRIPTION
The last bugfix on OutputMod actually didn't fix the problem where the skim output will have inconsistent information in the AllEvent tree.
To give a bit more detail: AllEvent tree is used to record the information of the events that were processed, including those which were skipped. Its only branch is a collection of EventHeader, and the header is filled with information in FillAllEventHeader function.
One piece of information that EventHeader holds is the entry number in the RunInfo tree for the corresponding run data. When we run the skim over multiple files, the RunInfo tree in the output file will no longer have the same ordering / entries. Therefore this specific variable fRunEntry must be updated in the EventHeaders. Before this bug fix, AllEventHeader was copied directly from the existing (in the input file) even header, and therefore could have a wrong fRunEntry value.

One more addition: For new NLO MC, events may not have uniform weights (can also be negative). The normalization given to the MC dataset will be determined by the cross section, the intL, and the sum of the weights (for LO this was equal to the number of events). Therefore when producing a skim, it is important to save the original sum of weights. AllEvent tree is best suited to carry this information, and in fact there is a variable fWeight in EventHeader which is not used at the moment. Therefore, in this update we set this weight variable to the MC event weight if the input is an MC file.