### PR TITLE
FastJetMod

### DIFF
--- a/PhysicsMod/interface/FastJetMod.h
+++ b/PhysicsMod/interface/FastJetMod.h
@@ -65,7 +65,7 @@ namespace mithep
         
     private:
 
-      UInt_t fJetAlgorithm = kCA;
+      UInt_t fJetAlgorithm = kAK;
       Bool_t fGetMatchBtag;                //=true if b-tag obtained by match with standard jets (AK5)
       Bool_t fUseBambuJets;                //=true if input small jets already present in bambu
       Bool_t fUseBambuFatJets;             //=true if input large jets already present in bambu

--- a/PhysicsMod/interface/FastJetMod.h
+++ b/PhysicsMod/interface/FastJetMod.h
@@ -39,13 +39,8 @@ namespace mithep
       void UseBambuJets(Bool_t b)               { fUseBambuJets = b;          }
 
       void SetBtaggedJetsName(const char *n)    { fBtaggedJetsName = n;       }
-      void SetBtaggedJetsFromBranch(Bool_t b)   { fBtaggedJetsFromBranch = b; }
-                                                                                                                                                  
       void SetJetsName(const char *n)           { fJetsName = n;              }
-      void SetJetsFromBranch(Bool_t b)          { fJetsFromBranch = b;        }
-                                                                              
       void SetPfCandidatesName(const char *n)   { fPfCandidatesName = n;      }
-      void SetPfCandidatesFromBranch(Bool_t b)  { fPfCandidatesFromBranch = b;}
 
       void SetOutputJetsName(const char *n)     { fOutputJetsName = n;        }
                                                                     
@@ -76,15 +71,12 @@ namespace mithep
       Bool_t fUseBambuFatJets;             //=true if input large jets already present in bambu
 
       TString fBtaggedJetsName;            //(i) name of input btagged jets
-      Bool_t fBtaggedJetsFromBranch;       //are input btagged jets from Branch?
       const PFJetCol *fBtaggedJets;        //input btagged jets
       
       TString fJetsName;                   //(i) name of input jets
-      Bool_t fJetsFromBranch;              //are input jets from Branch?
       const PFJetCol *fJets;               //input jets
 
       TString fPfCandidatesName;           //(i) name of PF candidates coll
-      Bool_t fPfCandidatesFromBranch;      //are PF candidates from Branch?
       const PFCandidateCol *fPfCandidates; //particle flow candidates coll handle
  
       TString fOutputJetsName;             //name of output jets collection

--- a/PhysicsMod/src/FastJetMod.cc
+++ b/PhysicsMod/src/FastJetMod.cc
@@ -14,16 +14,13 @@ ClassImp(mithep::FastJetMod)
 //--------------------------------------------------------------------------------------------------
 FastJetMod::FastJetMod(const char *name, const char *title) :
   BaseMod (name,title),
-  fGetMatchBtag (kTRUE),
+  fGetMatchBtag (kFALSE),
   fUseBambuJets (kFALSE),
   fBtaggedJetsName (Names::gkPFJetBrn),
-  fBtaggedJetsFromBranch (kTRUE),
   fBtaggedJets (0),
   fJetsName (Names::gkPFJetBrn),
-  fJetsFromBranch (kTRUE),
   fJets (0),
   fPfCandidatesName (Names::gkPFCandidatesBrn),
-  fPfCandidatesFromBranch(kTRUE),
   fPfCandidates (0),
   fOutputJetsName ("CA8FJCHS"),
   fOutputJets (0),
@@ -54,20 +51,20 @@ void FastJetMod::Process()
   
   // Get input collections
   if (fGetMatchBtag) {
-    LoadEventObject(fBtaggedJetsName,fBtaggedJets,fBtaggedJetsFromBranch);
+    fBtaggedJets = GetObject<PFJetCol>(fBtaggedJetsName);
     if (!fBtaggedJets) {
       SendError(kAbortModule,"Process","Pointer to input b-tagged jet collection %s null.",fBtaggedJetsName.Data());
       return;
     }
   }
   if (fUseBambuJets) {
-    LoadEventObject(fJetsName,fJets,fJetsFromBranch);
+    fJets = GetObject<PFJetCol>(fJetsName);
     if (!fJets) {
       SendError(kAbortModule,"Process","Pointer to input jet collection %s null.",fJetsName.Data());
       return;
     }
   }
-  LoadEventObject(fPfCandidatesName,fPfCandidates,fPfCandidatesFromBranch);
+  fPfCandidates = GetObject<PFCandidateCol>(fPfCandidatesName);
   if (!fPfCandidates) {
     SendError(kAbortModule,"Process","Pointer to input PF Cands collection %s null.",fPfCandidatesName.Data());
     return;
@@ -143,13 +140,6 @@ void FastJetMod::Process()
 //--------------------------------------------------------------------------------------------------
 void FastJetMod::SlaveBegin()
 {
-  // Run startup code on the computer (slave) doing the actual analysis. 
-  if (fGetMatchBtag)
-    ReqEventObject(fBtaggedJetsName,fBtaggedJets,fBtaggedJetsFromBranch);
-  if (fUseBambuJets)
-    ReqEventObject(fJetsName,fJets,fJetsFromBranch);
-  ReqEventObject(fPfCandidatesName,fPfCandidates,fPfCandidatesFromBranch);
-    
   // Jet definition constructor
   if (fJetAlgorithm == kKT)
     fJetDef = new fastjet::JetDefinition(fastjet::kt_algorithm, fJetConeSize);

--- a/PhysicsMod/src/FastJetMod.cc
+++ b/PhysicsMod/src/FastJetMod.cc
@@ -73,7 +73,6 @@ void FastJetMod::Process()
   // Create output collections
   fOutputJets = new JetOArr;
   fOutputJets->SetName(fOutputJetsName);
-  fOutputJets->SetOwner(kTRUE);
     
   std::vector<fastjet::PseudoJet> fjParts;
   // Push all particle flow candidates of the input PFjet into fastjet particle collection
@@ -95,16 +94,6 @@ void FastJetMod::Process()
   // Produce a new set of jets based on the fastjet particle collection and the defined clustering
   // Cut off fat jets with pt < fJetMinPt GeV
   std::vector<fastjet::PseudoJet> fjOutJets = sorted_by_pt(fjClustering->inclusive_jets(fJetMinPt)); 
-  // Check that the output collection size is non-null, otherwise nothing to be done further
-  if (fjOutJets.size() < 1) {
-    printf(" FastJetMod - WARNING - input PFCands produces null reclustering output!\n");
-
-    if (fjOutJets.size() > 0) 
-      fjClustering->delete_self_when_unused();
-    delete fjClustering;
-
-    return;
-  }
 
   // Now loop over PFJets and fill the output collection
   for (UInt_t j=0; j<fjOutJets.size(); ++j) {


### PR DESCRIPTION
I changed the way objects are loaded to match Yutaro's new method. I also removed some warnings and return of a NULL pointer that happens when the number of jets is zero. (This happens with a high pT cut.) I think it would be better to get an array with size 0 than an error during later mods. I changed the default algo to AKt, since it seems like everyone else uses that. I can change back though and change my workflow.