### PR TITLE
Adding ClassDef and linkdefs for Track/SV/LeptonData

### DIFF
--- a/DataTree/dict/FatJetColLinkDef.h
+++ b/DataTree/dict/FatJetColLinkDef.h
@@ -20,6 +20,13 @@
 #pragma link C++ nestedtypedef;
 #pragma link C++ namespace mithep;
 
+#pragma link C++ class mithep::FatJet::TrackData+;
+#pragma link C++ class std::vector<mithep::FatJet::TrackData>+;
+#pragma link C++ class mithep::FatJet::SVData+;
+#pragma link C++ class std::vector<mithep::FatJet::SVData>+;
+#pragma link C++ class mithep::FatJet::LeptonData+;
+#pragma link C++ class std::vector<mithep::FatJet::LeptonData>+;
+#pragma link C++ class std::vector<mithep::Vect3>+;
 #pragma link C++ class mithep::FatJet+;
 #pragma link C++ class mithep::Collection<mithep::FatJet>+;
 #pragma link C++ class mithep::Array<mithep::FatJet>+;

--- a/DataTree/interface/FatJet.h
+++ b/DataTree/interface/FatJet.h
@@ -20,73 +20,87 @@ namespace mithep {
   class FatJet : public PFJet {
   public:
     struct TrackData { // per track
-      float length;
-      float dist;
-      float dxy;
-      float dz;
-      float IP2D;
-      float IP2Dsig;
-      float IP;
-      float IPsig;
-      float IP2Derr;
-      float IPerr;
-      float prob;
-      float pt;
-      float eta;
-      float phi;
-      float PVWeight;
-      float SVWeight;
-      int PV;
-      int fromSV;
-      int SV;
+      Float_t length{};
+      Float_t dist{};
+      Float_t dxy{};
+      Float_t dz{};
+      Float_t IP2D{};
+      Float_t IP2Dsig{};
+      Float_t IP{};
+      Float_t IPsig{};
+      Float_t IP2Derr{};
+      Float_t IPerr{};
+      Float_t prob{};
+      Float_t pt{};
+      Float_t eta{};
+      Float_t phi{};
+      Float_t PVWeight{};
+      Float_t SVWeight{};
+      Int_t PV{};
+      Int_t fromSV{};
+      Int_t SV{};
+
+      TrackData() {}
+      virtual ~TrackData() {}
+
+      ClassDef(TrackData, 1)
     };
 
     struct SVData { // per SV
-      float flight;
-      float flightErr;
-      float deltaRJet;
-      float deltaRSumJet;
-      float deltaRSumDir;
-      float flight2D;
-      float flight2DErr;
-      float totCharge;
-      float vtxDistJetAxis;
-      int nTrk;
-      float mass;
-      float energyRatio;
-      float pt;
-      float eta;
-      float phi;
-      float dirX;
-      float dirY;
-      float dirZ;
+      Float_t flight{};
+      Float_t flightErr{};
+      Float_t deltaRJet{};
+      Float_t deltaRSumJet{};
+      Float_t deltaRSumDir{};
+      Float_t flight2D{};
+      Float_t flight2DErr{};
+      Float_t totCharge{};
+      Float_t vtxDistJetAxis{};
+      Int_t nTrk{};
+      Float_t mass{};
+      Float_t energyRatio{};
+      Float_t pt{};
+      Float_t eta{};
+      Float_t phi{};
+      Float_t dirX{};
+      Float_t dirY{};
+      Float_t dirZ{};
+
+      SVData() {}
+      virtual ~SVData() {}
+
+      ClassDef(SVData, 1)
     };
 
     struct LeptonData {
-      float pt;
-      float eta;
-      float phi;
-      float ptRel;
-      float ratio;
-      float ratioRel;
-      float IP;
-      float IP2D;
+      Float_t pt{};
+      Float_t eta{};
+      Float_t phi{};
+      Float_t ptRel{};
+      Float_t ratio{};
+      Float_t ratioRel{};
+      Float_t IP{};
+      Float_t IP2D{};
+
+      LeptonData() {}
+      virtual ~LeptonData() {}
+
+      ClassDef(LeptonData, 1)
     };
 
-    FatJet() : PFJet() {}
+    FatJet() {}
     FatJet(PFJet const& p) : PFJet(p) {}
     ~FatJet() {}
 
     EObjType ObjType() const override { return kFatJet; }
 
-    float Charge() const                { return fCharge; }
-    float Tau1IVF() const               { return fTau1IVF; }
-    float Tau2IVF() const               { return fTau2IVF; }
-    float Tau3IVF() const               { return fTau3IVF; }
-    Vect3    const & GetTauIVFAxis(UInt_t i) const { return fTauIVFAxes.at(i); }
-    float tauDot() const                { return fTauDot; }
-    float zRatio() const                { return fZRatio; }
-
+    Float_t Charge() const                { return fCharge; }
+    Float_t Tau1IVF() const               { return fTau1IVF; }
+    Float_t Tau2IVF() const               { return fTau2IVF; }
+    Float_t Tau3IVF() const               { return fTau3IVF; }
+    Float_t tauDot() const                { return fTauDot; }
+    Float_t zRatio() const                { return fZRatio; }
+    Vect3 const& GetTauIVFAxis(UInt_t i) const { return fTauIVFAxes.at(i); }
 
     Jet* MakeCopy() const override { return new FatJet(*this); }
 
@@ -94,39 +108,38 @@ namespace mithep {
     std::vector<SVData> const&     GetSVData() const       { return fSVData; }
     std::vector<LeptonData> const& GetMuonData() const     { return fMuonData; }
     std::vector<LeptonData> const& GetElectronData() const { return fElectronData; }
-    std::vector<float> const& GetSubJetBtags() const       { return fSubjetBtags; }
-
+    std::vector<Float_t> const& GetSubJetBtags() const     { return fSubjetBtags; }
 
     void SetCharge()                    { fCharge  = this->GetCharge(); }
-    void SetTau1IVF(float t)         { fTau1IVF        = t; }
-    void SetTau2IVF(float t)         { fTau2IVF        = t; }
-    void SetTau3IVF(float t)         { fTau3IVF        = t; }
+    void SetTau1IVF(Float_t t)         { fTau1IVF        = t; }
+    void SetTau2IVF(Float_t t)         { fTau2IVF        = t; }
+    void SetTau3IVF(Float_t t)         { fTau3IVF        = t; }
     void AddTauIVFAxis(Vect3 p)         { fTauIVFAxes.push_back(p); }
 
-    void SetTauDot(float t)          { fTauDot = t; }
-    void SetZRatio(float t)          { fZRatio = t; }
+    void SetTauDot(Float_t t)          { fTauDot = t; }
+    void SetZRatio(Float_t t)          { fZRatio = t; }
     void AddTrackData(TrackData *t)     { fTrackData.push_back(*t); }
     void AddSVData(SVData *s)           { fSVData.push_back(*s); }
     void AddMuonData(LeptonData *s)     { fMuonData.push_back(*s); }
     void AddElectronData(LeptonData *s) { fElectronData.push_back(*s); }
-    void AddSubJetBtag(float btag) { fSubjetBtags.push_back(btag); }
+    void AddSubJetBtag(Float_t btag) { fSubjetBtags.push_back(btag); }
 
 
   protected:
     Double_t GetCharge() const override;
 
-    float         fCharge{0.};       //Pt-weighted jet charge
-    float         fTau1IVF{-1.};         //1-subjettiness
-    float         fTau2IVF{-1.};         //2-subjettiness
-    float         fTau3IVF{-1.};         //3-subjettiness
+    Float_t         fCharge{0.};       //Pt-weighted jet charge
+    Float_t         fTau1IVF{-1.};         //1-subjettiness
+    Float_t         fTau2IVF{-1.};         //2-subjettiness
+    Float_t         fTau3IVF{-1.};         //3-subjettiness
     std::vector<Vect3> fTauIVFAxes{};
 
-    std::vector<float> fSubjetBtags; // ordered by decreasing subjet pT
+    std::vector<Float_t> fSubjetBtags; // ordered by decreasing subjet pT
 
 
     // IVF variables
-    float         fTauDot{-1.};
-    float         fZRatio{-1.};
+    Float_t         fTauDot{-1.};
+    Float_t         fZRatio{-1.};
     std::vector<TrackData>  fTrackData{};
     std::vector<SVData>     fSVData{};
     std::vector<LeptonData> fMuonData{};
@@ -137,8 +150,6 @@ namespace mithep {
 
 }
 
-
-
 //--------------------------------------------------------------------------------------------------
 inline
 Double_t
@@ -146,13 +157,11 @@ mithep::FatJet::GetCharge() const
 {
   // Return the sum of constituents PFCandidates weighted by their pt
 
-  float charge = 0;
+  Float_t charge = 0;
   for (UInt_t i = 0; i< NPFCands(); ++i)
     charge += PFCand(i)->Charge() * PFCand(i)->Pt();
 
   return charge / Pt();
 }
-
-
 
 #endif


### PR DESCRIPTION
One of the failure mode in the current 042 tag is in the XML parsing, but we have been seeing "data corrupted" type of errors in FatJet. It is highly unlikely that the XML problem will cause only the FatJet class to be corrupted, so as a safety measure I'm adding ClassDef and linkdef lines for the nested structs in FatJet. In fact, as far as I know, we have never had classes with nested class / struct (and std::vector thereof) being written to Bambu files, and it's not clear to me whether it is enough to have a dictionary for FatJet. In fact, we had no Streamer for the Track/SV/LeptonData structs (now we do).