### PR TITLE
Full local caching

### DIFF
--- a/Catalog/src/Catalog.cc
+++ b/Catalog/src/Catalog.cc
@@ -27,7 +27,7 @@ Dataset *Catalog::FindDataset(const char *book, const char *dataset, const char 
   //       =2 - translate them into local files, no caching wait for Cacher mechanism
   //       =3 - translate them into local files under PWD
 
-  printf(" Catalog: %s, Book: %s, Dataset: %s, Fileset: %s",fLocation.Data(),book,dataset,fileset);
+  printf(" Catalog: %s, Book: %s, Dataset: %s, Fileset: %s\n",fLocation.Data(),book,dataset,fileset);
 
   TString slash        = "/";
   TString fullDir      = fLocation +slash+ TString(book) +slash+ TString(dataset);

--- a/DataUtil/interface/Cacher.h
+++ b/DataUtil/interface/Cacher.h
@@ -21,7 +21,7 @@ namespace mithep
   {
   public:
     Cacher(const TList *list, Bool_t fullLocal);
-    virtual ~Cacher() {}
+    virtual ~Cacher();
     
     Bool_t               InitialCaching();
     Bool_t               NextCaching();
@@ -35,7 +35,7 @@ namespace mithep
     Bool_t               SubmitCacheRequest(const char* file, Bool_t initial);
     void                 RemoveTemporaryFile(int idx);
 
-    const TList         *fInputList;          //in bambu several input files can be handled in
+    TList               *fInputList;          //in bambu several input files can be handled in
                                               //parallel we do not (yet) implement this here
     Bool_t               fFullLocal;          //when true, call cache request command with special options
     Int_t                fCurrentFileIdx;     //index of currently processing file

--- a/DataUtil/interface/Cacher.h
+++ b/DataUtil/interface/Cacher.h
@@ -34,8 +34,8 @@ namespace mithep
   protected:
     
   private:
-    Bool_t               SubmitCacheRequest(const char* file, Bool_t initial);
-    void                 RemoveTemporaryFile(int idx);
+    Bool_t               SubmitCacheRequest(const char* file, Bool_t initial) const;
+    void                 RemoveTemporaryFile(int idx) const;
 
     TList               *fInputList;          //in bambu several input files can be handled in
                                               //parallel we do not (yet) implement this here

--- a/DataUtil/interface/Cacher.h
+++ b/DataUtil/interface/Cacher.h
@@ -20,22 +20,24 @@ namespace mithep
   class Cacher
   {
   public:
-    Cacher(const TList *list);
+    Cacher(const TList *list, Bool_t fullLocal);
     virtual ~Cacher() {}
     
     Bool_t               InitialCaching();
     Bool_t               NextCaching();
     Bool_t               Exists(const char* file);
     void                 CleanCache();
+    void                 SetNFilesAhead(Int_t n) { fNFilesAhead = n; }
     
   protected:
     
   private:
-    Bool_t               SubmitCacheRequest(const char* file);
+    Bool_t               SubmitCacheRequest(const char* file, Bool_t initial);
     void                 RemoveTemporaryFile(int idx);
 
     const TList         *fInputList;          //in bambu several input files can be handled in
                                               //parallel we do not (yet) implement this here
+    Bool_t               fFullLocal;          //when true, call cache request command with special options
     Int_t                fCurrentFileIdx;     //index of currently processing file
     Int_t                fCachedFileIdx;      //index of last cached file
     Int_t                fNFilesAhead;        //number of files to cache ahead of running job

--- a/DataUtil/interface/Cacher.h
+++ b/DataUtil/interface/Cacher.h
@@ -25,8 +25,10 @@ namespace mithep
     
     Bool_t               InitialCaching();
     Bool_t               NextCaching();
-    Bool_t               Exists(const char* file);
-    void                 CleanCache();
+    Bool_t               Exists(const char* file) const;
+    Bool_t               NextFileReady() const;
+    void                 CleanCache() const;
+    void                 Wait();
     void                 SetNFilesAhead(Int_t n) { fNFilesAhead = n; }
     
   protected:

--- a/DataUtil/interface/Cacher.h
+++ b/DataUtil/interface/Cacher.h
@@ -21,29 +21,34 @@ namespace mithep
   {
   public:
     Cacher(const TList *list, Bool_t fullLocal);
-    virtual ~Cacher();
+    virtual ~Cacher() {}
     
     Bool_t               InitialCaching();
     Bool_t               NextCaching();
+    Bool_t               WaitForNextFile();
     Bool_t               Exists(const char* file) const;
-    Bool_t               NextFileReady() const;
     void                 CleanCache() const;
-    void                 Wait();
     void                 SetNFilesAhead(Int_t n) { fNFilesAhead = n; }
+    void                 SetWaitLength(Int_t n) { fWaitLength = n; }
+    void                 SetTimeout(Int_t n) { fTimeout = n; }
     
   protected:
     
   private:
     Bool_t               SubmitCacheRequest(const char* file, Bool_t initial) const;
     void                 RemoveTemporaryFile(int idx) const;
+    void                 Wait();
 
-    TList               *fInputList;          //in bambu several input files can be handled in
+    TList                fInputList;          //in bambu several input files can be handled in
                                               //parallel we do not (yet) implement this here
     Bool_t               fFullLocal;          //when true, call cache request command with special options
     Int_t                fCurrentFileIdx;     //index of currently processing file
     Int_t                fCachedFileIdx;      //index of last cached file
     Int_t                fNFilesAhead;        //number of files to cache ahead of running job
-    Int_t                fNSecWait;           //keep track how many seconds we were waiting
+    Int_t                fCumulativeWait;     //keep track how many seconds we were waiting
+    Int_t                fCurrentWait;        //wait time of the current file
+    Int_t                fWaitLength;         //unit wait length
+    Int_t                fTimeout;            //timeout until aborting analysis
     std::vector<int>     fCacheStatus;        //0-nothing, 1-submitted, 2-complete
   };
 }

--- a/DataUtil/src/Cacher.cc
+++ b/DataUtil/src/Cacher.cc
@@ -124,7 +124,7 @@ Bool_t Cacher::NextCaching()
 }
 
 //--------------------------------------------------------------------------------------------------
-Bool_t Cacher::SubmitCacheRequest(const char* file, Bool_t initial)
+Bool_t Cacher::SubmitCacheRequest(const char* file, Bool_t initial) const
 {
   // Submit a Cache request for the specified file
 
@@ -171,7 +171,7 @@ Bool_t Cacher::NextFileReady() const
 }
 
 //--------------------------------------------------------------------------------------------------
-void Cacher::RemoveTemporaryFile(int idx)
+void Cacher::RemoveTemporaryFile(int idx) const
 {
   // Remove completed file if it was a temporary download
   if (idx > -1 && idx < fInputList->GetEntries()) {
@@ -185,7 +185,7 @@ void Cacher::RemoveTemporaryFile(int idx)
 }
 
 //--------------------------------------------------------------------------------------------------
-void Cacher::CleanCache()
+void Cacher::CleanCache() const
 {
   // there is nothing really do delete in terms of objects but the potential local file
   // copies need to be removed

--- a/DataUtil/src/Cacher.cc
+++ b/DataUtil/src/Cacher.cc
@@ -117,8 +117,7 @@ Bool_t Cacher::NextCaching()
 
     MDB(kTreeIO, 2)
       Info("Cacher::NextCaching","waiting for completion (10 sec)");
-    fNSecWait += 10;
-    sleep(10); // wait 10 seconds
+    Wait();
   }
 
   return status;
@@ -149,7 +148,7 @@ Bool_t Cacher::SubmitCacheRequest(const char* file, Bool_t initial)
 }
 
 //--------------------------------------------------------------------------------------------------
-Bool_t Cacher::Exists(const char* file)
+Bool_t Cacher::Exists(const char* file) const
 {
   // Check if the specified file exists
 
@@ -160,6 +159,15 @@ Bool_t Cacher::Exists(const char* file)
 	 gSystem->GetPathInfo(file,id,size,flags,mt));
 
   return (gSystem->GetPathInfo(file,id,size,flags,mt) == 0);
+}
+
+//--------------------------------------------------------------------------------------------------
+Bool_t Cacher::NextFileReady() const
+{
+  if (fCurrentFileIdx == fInputList->GetEntries() - 1)
+    return true;
+
+  return Exists(fInputList->At(fCurrentFileIdx + 1)->GetName());
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -189,4 +197,11 @@ void Cacher::CleanCache()
   // Give a summary of the cache waiting time
   Info("Cacher::CleanCache","\n         total waiting time for caching %d sec (%f min)\n\n",
        fNSecWait,fNSecWait/60.);
+}
+
+//--------------------------------------------------------------------------------------------------
+void Cacher::Wait()
+{
+  fNSecWait += 10;
+  sleep(10); // wait 10 seconds
 }

--- a/DataUtil/src/Cacher.cc
+++ b/DataUtil/src/Cacher.cc
@@ -7,7 +7,7 @@ using namespace mithep;
 
 //--------------------------------------------------------------------------------------------------
 Cacher::Cacher(const TList *list, Bool_t fullLocal) :
-  fInputList(list),
+  fInputList(new TList),
   fFullLocal(fullLocal),
   fCurrentFileIdx(-1),
   fCachedFileIdx(-1),
@@ -15,12 +15,21 @@ Cacher::Cacher(const TList *list, Bool_t fullLocal) :
   fNSecWait(0)
 {
   // Constructor
+  fInputList->SetOwner();
+  // deep clone the input list
+  for (TObject* objStr : *list)
+    fInputList->Add(new TObjString(objStr->GetName()));
 
   // create the synchronized cache status vector
   for (Int_t i=0; i<fInputList->GetEntries(); i++) {
     int status = 0;
     fCacheStatus.push_back(status);
   }
+}
+
+Cacher::~Cacher()
+{
+  delete fInputList;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/DataUtil/src/Cacher.cc
+++ b/DataUtil/src/Cacher.cc
@@ -1,4 +1,5 @@
 #include <TSystem.h>
+#include <TObjString.h>
 #include "MitAna/DataUtil/interface/Debug.h"
 #include "MitAna/DataUtil/interface/Cacher.h"
 

--- a/DataUtil/src/Cacher.cc
+++ b/DataUtil/src/Cacher.cc
@@ -16,7 +16,7 @@ Cacher::Cacher(const TList *list, Bool_t fullLocal) :
   fCumulativeWait(0),
   fCurrentWait(0),
   fWaitLength(10),
-  fTimeout(600)
+  fTimeout(1200)
 {
   // Constructor
   fInputList.SetOwner();

--- a/TreeMod/interface/AnaFwkMod.h
+++ b/TreeMod/interface/AnaFwkMod.h
@@ -27,7 +27,6 @@ namespace mithep
       AnaFwkMod(const char *name="AnaFwkMod", 
                 const char *title="Analysis framework module");
 
-      void             SetInputLists(const TList *l);
       Long64_t         GetPrintScale()            const { return fPrintScale;  }
       Long64_t         GetSkipNEvents()           const { return fSkipNEvents; }
       void             SetPrintScale(UInt_t n)          { fPrintScale  = n;    }
@@ -43,7 +42,6 @@ namespace mithep
 
       TString          fAllHeadTreeName;   //all events tree name
       TString          fAllHeadBrName;     //all event headers branch name
-      const TList     *fInputLists;        //input lists (cannot be changed)
       Long64_t         fSkipNEvents;       //number of events to skip from beginning (def=0)
       UInt_t           fPrintScale;        //scale of when to print event number/timings (def=100)
       TStopwatch      *fSWtotal;           //!stop watch for overall timing

--- a/TreeMod/interface/AnaFwkMod.h
+++ b/TreeMod/interface/AnaFwkMod.h
@@ -10,7 +10,6 @@
 #define MITANA_TREEEMOD_ANAFWKMOD_H
 
 #include "MitAna/TreeMod/interface/BaseMod.h" 
-#include "MitAna/DataUtil/interface/Cacher.h" 
 #include "MitAna/DataTree/interface/EventHeaderCol.h"
 #include "MitAna/DataTree/interface/MCEventInfo.h"
 #include "MitAna/DataTree/interface/PileupInfoFwd.h"
@@ -29,7 +28,6 @@ namespace mithep
                 const char *title="Analysis framework module");
 
       void             SetInputLists(const TList *l);
-      void             SetUseCacher(Int_t i)            { fUseCacher = i;  }
       Long64_t         GetPrintScale()            const { return fPrintScale;  }
       Long64_t         GetSkipNEvents()           const { return fSkipNEvents; }
       void             SetPrintScale(UInt_t n)          { fPrintScale  = n;    }
@@ -46,8 +44,6 @@ namespace mithep
       TString          fAllHeadTreeName;   //all events tree name
       TString          fAllHeadBrName;     //all event headers branch name
       const TList     *fInputLists;        //input lists (cannot be changed)
-      Int_t            fUseCacher;         //switch on caching of files
-      Cacher          *fCacher;            //caching tool
       Long64_t         fSkipNEvents;       //number of events to skip from beginning (def=0)
       UInt_t           fPrintScale;        //scale of when to print event number/timings (def=100)
       TStopwatch      *fSWtotal;           //!stop watch for overall timing

--- a/TreeMod/interface/Analysis.h
+++ b/TreeMod/interface/Analysis.h
@@ -127,7 +127,7 @@ namespace mithep
       };
 
       Bool_t                    fUseProof;        //=true if PROOF is to be used (def=0)
-      Bool_t                    fUseCacher;       //=1 use file caching (def=0)
+      Int_t                     fUseCacher;       //=1 use file caching, =2 use full-local caching (def=0)
       UInt_t                    fUseHLT;          //=1 if HLTFwkMod is to be used, 2 to process input with no HLT info (def=1)
       Bool_t                    fUseMC;           //=true if MCFwkMod is to be used (def=false)
       Bool_t                    fHierarchy;       //=true if module hierachy to be stored (def=1)

--- a/TreeMod/interface/Selector.h
+++ b/TreeMod/interface/Selector.h
@@ -12,6 +12,7 @@
 #include "MitAna/TAM/interface/TAModule.h" 
 #include "MitAna/TAM/interface/TAMSelector.h" 
 #include "MitAna/TAM/interface/TAMVirtualBranchLoader.h" 
+#include "MitAna/DataUtil/interface/Cacher.h" 
 #include "MitAna/DataCont/interface/BaseCollection.h"
 #include "MitAna/DataCont/interface/ObjArray.h"
 #include "MitAna/DataTree/interface/EventHeader.h" 
@@ -57,6 +58,7 @@ namespace mithep {
     void                 SetRunInfoName(const char* n)    { fRunInfoName    = n; }
     void                 SetMCRunInfoName(const char* n)  { fMCRunInfoName  = n; }
     void                 SetRunTreeName(const char* n)    { fRunTreeName    = n; }
+    void                 SetUseCacher(Int_t i)            { fUseCacher      = i; }
     void                 AddOutputMod(OutputMod*);
 
     class ObjInfo : public TNamed {
@@ -112,6 +114,7 @@ namespace mithep {
     Bool_t               Notify() override;
     Bool_t               Process(Long64_t entry) override;
     void                 SlaveBegin(TTree* tree) override;
+    void                 SlaveTerminate() override;
     void                 UpdateRunInfo();
     void                 UpdateRunInfoTree();
     TObject*             GetObjectImpl(TClass const*, char const* name, Bool_t warn);
@@ -120,6 +123,8 @@ namespace mithep {
                                            char const* name, Bool_t warn);
 
     Bool_t               fDoRunInfo;      //=true then get RunInfo (def=1)
+    Int_t                fUseCacher;      //switch on caching of files
+    Cacher              *fCacher;         //caching tool
     TString              fEvtHdrName;     //name of event header branch
     TString              fRunTreeName;    //name of run info tree
     TString              fRunInfoName;    //name of run info branch

--- a/TreeMod/src/AnaFwkMod.cc
+++ b/TreeMod/src/AnaFwkMod.cc
@@ -18,8 +18,6 @@ AnaFwkMod::AnaFwkMod(const char *name, const char *title) :
   fAllHeadTreeName(Names::gkAllEvtTreeName),
   fAllHeadBrName(Names::gkAllEvtHeaderBrn),
   fInputLists(0),
-  fUseCacher(0),
-  fCacher(0),
   fSkipNEvents(0),
   fPrintScale(1),
   fSWtotal(0),
@@ -159,10 +157,6 @@ Bool_t AnaFwkMod::Notify()
 {
   // Make sure to get the new "AllEvents" tree when the file changes.
 
-  // make sure to keep files cached
-  if (fCacher)
-    fCacher->NextCaching();
-
   fReload = kTRUE;
   return kTRUE;
 }
@@ -262,14 +256,6 @@ void AnaFwkMod::SlaveBegin()
 {
   // Book our histogram and start the stop watches.
 
-  // perfrom initial caching before we get rolling
-  if (fUseCacher > 0) {
-    fCacher = new Cacher(dynamic_cast<TList*>(fInputLists->At(0)), fUseCacher == 2); // 2: full-local caching
-    if (fUseCacher == 2)
-      fCacher->SetNFilesAhead(1); // do not download too many files locally
-    fCacher->InitialCaching();
-  }
-
   // set the stop watches
   fSWtotal = new TStopwatch;
   fSWevent = new TStopwatch;
@@ -304,12 +290,6 @@ void AnaFwkMod::SlaveTerminate()
   // Fill event histogram and printout timing information.
 
   RetractObj(fAllHeaders.GetName());
-
-  // Clean leftovers in cache
-  if (fCacher) {
-    fCacher->CleanCache();
-    delete fCacher;
-  }
 
   SaveNEventsProcessed();
   TH1D *hDAllEvents = new TH1D("hDAllEvents","Sum of processed and skimmed events",1,-0.5,0.5);

--- a/TreeMod/src/AnaFwkMod.cc
+++ b/TreeMod/src/AnaFwkMod.cc
@@ -160,7 +160,7 @@ Bool_t AnaFwkMod::Notify()
   // Make sure to get the new "AllEvents" tree when the file changes.
 
   // make sure to keep files cached
-  if (fUseCacher > 0 && fCacher)
+  if (fCacher)
     fCacher->NextCaching();
 
   fReload = kTRUE;
@@ -255,7 +255,8 @@ void AnaFwkMod::Process()
 //--------------------------------------------------------------------------------------------------
 void AnaFwkMod::SetInputLists(const TList *l) {
   fInputLists = l;
-  fCacher = new Cacher(dynamic_cast<TList*>(fInputLists->At(0)));
+  if (fUseCacher > 0)
+    fCacher = new Cacher(dynamic_cast<TList*>(fInputLists->At(0)), fUseCacher == 2); // 2: full-local caching
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -264,7 +265,7 @@ void AnaFwkMod::SlaveBegin()
   // Book our histogram and start the stop watches.
 
   // perfrom initial caching before we get rolling
-  if (fUseCacher > 0 && fCacher)
+  if (fCacher)
     fCacher->InitialCaching();
 
   // set the stop watches
@@ -303,7 +304,7 @@ void AnaFwkMod::SlaveTerminate()
   RetractObj(fAllHeaders.GetName());
 
   // Clean leftovers in cache
-  if (fUseCacher > 0 && fCacher) {
+  if (fCacher) {
     fCacher->CleanCache();
     delete fCacher;
   }

--- a/TreeMod/src/AnaFwkMod.cc
+++ b/TreeMod/src/AnaFwkMod.cc
@@ -17,7 +17,6 @@ AnaFwkMod::AnaFwkMod(const char *name, const char *title) :
   BaseMod(name,title),
   fAllHeadTreeName(Names::gkAllEvtTreeName),
   fAllHeadBrName(Names::gkAllEvtHeaderBrn),
-  fInputLists(0),
   fSkipNEvents(0),
   fPrintScale(1),
   fSWtotal(0),
@@ -244,11 +243,6 @@ void AnaFwkMod::Process()
          fSWevent->CpuTime()/nProcessed);
     fSWevent->Start();
   }
-}
-
-//--------------------------------------------------------------------------------------------------
-void AnaFwkMod::SetInputLists(const TList *l) {
-  fInputLists = l;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/TreeMod/src/AnaFwkMod.cc
+++ b/TreeMod/src/AnaFwkMod.cc
@@ -255,8 +255,6 @@ void AnaFwkMod::Process()
 //--------------------------------------------------------------------------------------------------
 void AnaFwkMod::SetInputLists(const TList *l) {
   fInputLists = l;
-  if (fUseCacher > 0)
-    fCacher = new Cacher(dynamic_cast<TList*>(fInputLists->At(0)), fUseCacher == 2); // 2: full-local caching
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -265,8 +263,12 @@ void AnaFwkMod::SlaveBegin()
   // Book our histogram and start the stop watches.
 
   // perfrom initial caching before we get rolling
-  if (fCacher)
+  if (fUseCacher > 0) {
+    fCacher = new Cacher(dynamic_cast<TList*>(fInputLists->At(0)), fUseCacher == 2); // 2: full-local caching
+    if (fUseCacher == 2)
+      fCacher->SetNFilesAhead(1); // do not download too many files locally
     fCacher->InitialCaching();
+  }
 
   // set the stop watches
   fSWtotal = new TStopwatch;

--- a/TreeMod/src/Analysis.cc
+++ b/TreeMod/src/Analysis.cc
@@ -470,7 +470,6 @@ Bool_t Analysis::Init()
 
   // create our ana framework module
   AnaFwkMod *anamod = new AnaFwkMod;
-  anamod->SetInputLists(fList);
   anamod->SetSkipNEvents(fSkipNEvents);
   anamod->SetPrintScale(fPrintScale);
   fDeleteList->Add(anamod);

--- a/TreeMod/src/Analysis.cc
+++ b/TreeMod/src/Analysis.cc
@@ -470,8 +470,8 @@ Bool_t Analysis::Init()
 
   // create our ana framework module
   AnaFwkMod *anamod = new AnaFwkMod;
-  anamod->SetInputLists(fList);
   anamod->SetUseCacher(fUseCacher);
+  anamod->SetInputLists(fList);
   anamod->SetSkipNEvents(fSkipNEvents);
   anamod->SetPrintScale(fPrintScale);
   fDeleteList->Add(anamod);

--- a/TreeMod/src/Analysis.cc
+++ b/TreeMod/src/Analysis.cc
@@ -470,7 +470,6 @@ Bool_t Analysis::Init()
 
   // create our ana framework module
   AnaFwkMod *anamod = new AnaFwkMod;
-  anamod->SetUseCacher(fUseCacher);
   anamod->SetInputLists(fList);
   anamod->SetSkipNEvents(fSkipNEvents);
   anamod->SetPrintScale(fPrintScale);
@@ -516,6 +515,7 @@ Bool_t Analysis::Init()
     fSelector->SetDoProxy(fDoProxy);
     fSelector->SetDoObjTabClean(fDoObjTabClean);
     fSelector->SetDoRunInfo(kTRUE);
+    fSelector->SetUseCacher(fUseCacher);
     fSelector->SetAllEvtHdrBrn(GetAllEvtHdrBrn());
     fSelector->SetAllEvtTreeName(GetAllEvtTreeName());
     fSelector->SetEvtHdrName(GetEvtHdrName());

--- a/TreeMod/src/Selector.cc
+++ b/TreeMod/src/Selector.cc
@@ -152,6 +152,12 @@ Bool_t Selector::Process(Long64_t entry)
     }
   }
 
+  if (fCacher && fTree && fTree->GetTree()->GetReadEntry() == fTree->GetTree()->GetEntries() - 1) {
+    // process has reached the end of the current file
+    while (!fCacher->NextFileReady()) // potential deadlock similar to Cacher::NextCaching
+      fCacher->Wait();
+  }
+
   return ret;
 }
 

--- a/TreeMod/src/Selector.cc
+++ b/TreeMod/src/Selector.cc
@@ -183,8 +183,7 @@ void Selector::SlaveBegin(TTree *tree)
         inputList.Add(new TObjString(obj->GetTitle()));
 
       fCacher = new Cacher(&inputList, fUseCacher == 2); // 2: full-local caching
-      if (fUseCacher == 2)
-        fCacher->SetNFilesAhead(1); // do not download too many files locally
+      fCacher->SetNFilesAhead(1); // do not download too many files locally
       if (!fCacher->InitialCaching()) {
         Error("SlaveBegin", "Initial cache failed.");
         throw std::exception();

--- a/bin/requestFile.sh
+++ b/bin/requestFile.sh
@@ -91,7 +91,7 @@ then
   fi
 elif [ "$localopt" = "copy" ] && [ -e $cache ]
 then
-  hdfs dfs -get $cache $file &
+  hdfs dfs -get /cms$lfn $file &
   exit 0
 fi
 

--- a/bin/requestFile.sh
+++ b/bin/requestFile.sh
@@ -8,16 +8,25 @@ h=`basename $0`
 # start waiting time now
 startTime=$(date +%s)
 
-FILE="$1"
+file="$1"
 
-if [ -e "$FILE" ]
+if [ -e "$file" ]
 then
-  echo " $h - Found file: $FILE. EXIT!"
+  echo " $h - Found file: $file. EXIT!"
   exit 0
 fi
 
-filename=`basename $FILE`
-dirName=`dirname $FILE`
+localopt=""
+if [ "$2" = "-L" ]
+then
+  localopt="link"
+elif [ "$2" = "-C" ]
+then
+  localopt="copy"
+fi
+
+filename=`basename $file`
+dirName=`dirname $file`
 
 dataset=`basename $dirName`
 dirName=`dirname $dirName`
@@ -27,32 +36,68 @@ dirName=`dirname $dirName`
 
 book=`basename $dirName`
 
-rc=0
-if [ -e "/usr/local/DynamicData/SmartCache/setup.sh" ] && \
-   [ "`echo $FILE | grep ^/mnt/hadoop/cms`" != "" ]
+lfdir=/store/user/paus/$book/$version/$dataset
+lfn=$lfdir/$filename
+
+cache=/mnt/hadoop/cms$lfn
+
+if [ -e "/usr/local/DynamicData/SmartCache/setup.sh" ]
 then
-  # do not ask me why I do this! PYTHON MADNESS
-  user=$USER; unset -v `env | sed -e 's/=.*//'`; export USER=$user; export PATH=/bin:/usr/bin
-  source /home/$user/.bashrc
-  # worst patch in a long time #
+  if ( [ "$localopt" ] && [ ! -e $cache ] ) || [[ $file =~ ^/mnt/hadoop/cms ]]
+  then
+    # first condition = Copy from hadoop cache requested but the cache does not exist
+    # -> for this job will use xrdcp but at the same time request a cache download
+    # second condition = Hadoop cache requested. Submit a download request regardless of
+    # the cache existence. Download will not happen if the cache exists.
 
-  source /usr/local/DynamicData/SmartCache/setup.sh
-  export PATH="${PATH}:$SMARTCACHE_DIR/Client"
-
-  echo " Making request:"
-  echo " -> addDownloadRequest.py --file=$filename --dataset=$dataset --book=$book/$version"
-  addDownloadRequest.py --file=$filename --dataset=$dataset --book=$book/$version
-  rc="$?"
-else
-  server="xrootd.cmsaf.mit.edu"
-  echo " $h - SmartCache not available or not requested.. trying xrootd cp (xrdcp)."
-  echo " -> xrdcp from $server to ./store/user/paus/$book/$version/$dataset/$filename"
-  mkdir -p ./store/user/paus/$book/$version/$dataset
-  ( xrdcp -s root://${server}//store/user/paus/$book/$version/$dataset/$filename \
-                            ./store/user/paus/$book/$version/$dataset/$filename.xrdcp && \
-    mv ./store/user/paus/$book/$version/$dataset/$filename.xrdcp \
-       ./store/user/paus/$book/$version/$dataset/$filename ) &
+    # do not ask me why I do this! PYTHON MADNESS
+    user=$USER; unset -v `env | sed -e 's/=.*//'`; export USER=$user; export PATH=/bin:/usr/bin
+    source /home/$user/.bashrc
+    # worst patch in a long time #
   
+    source /usr/local/DynamicData/SmartCache/setup.sh
+    export PATH="${PATH}:$SMARTCACHE_DIR/Client"
+  
+    echo " Making request:"
+    echo " -> addDownloadRequest.py --file=$filename --dataset=$dataset --book=$book/$version"
+    addDownloadRequest.py --file=$filename --dataset=$dataset --book=$book/$version
+    rc="$?"
+
+    if [ "$localopt" != "copy" ]
+    then
+      exit $rc
+    fi
+  fi
 fi
 
-exit $rc
+if ! [[ $file =~ ^\./ ]]
+then
+  echo " $h - SmartCache not available or not requested, but the destination is not local. EXIT!"
+  exit 1
+fi
+
+destdir=.$lfdir
+
+mkdir -p $destdir
+
+if [ "$localopt" = "link" ]
+then
+  if [ -e $cache ]
+  then
+    ln -s $cache $file
+    exit $?
+  else
+    echo " $h - Link to cache requested, but the cache does not exist. Proceeding with download."
+  fi
+elif [ "$localopt" = "copy" ] && [ -e $cache ]
+then
+  hdfs dfs -get $cache $file &
+  exit 0
+fi
+
+server="xrootd.cmsaf.mit.edu"
+echo " $h - SmartCache not available or not requested.. trying xrootd cp (xrdcp)."
+echo " -> xrdcp from $server to ./store/user/paus/$book/$version/$dataset/$filename"
+( xrdcp -s root://${server}/$lfn $file.xrdcp && mv $file.xrdcp $file ) &
+
+exit 0


### PR DESCRIPTION
This is the branch I have been running my jobs with recently. Full-local caching (download from local hadoop onto the worker node disk) is implemented through new options in the Cacher and Catalog.
It involved some surgeries for the following reason:
*  The current cacher implementation has a hard-coded number of files to cache ahead, which is 2.
*  Each condor job downloading 2 files on top of the one that is being processed is a bit too much. The jobs can reach the allocated space limit and get held. So in full-local mode, we should only cache 1 file ahead.
*  Making Cacher configurable was simple. However, only one file ahead means that the following can happen:
  1. File i gets done, with file i+1 in the cache.
  2. Job checks that file i+1 exists.
  3. Job starts working on file i+1 while downloading file i+2.
  4. Job goes through i+1 before i+2 arrives.
*  With two files in the cache, step ii. would look for file i+2, so we never encounter this problem.
*  If this happens, ROOT does not wait but rather says it will look for the next file, which of course also does not exist. So the next-to-next is looked for, and so on - in effect the job finishes here prematurely.
*  In order to prevent this, we need the framework to stop and check that the next file exists when it reaches the last event of the current file.
*  This information (event index within the current tree) is best accessed from the Selector object.
*  Cacher was owned by AnaFwkMod, but for the above reason it should be moved to Selector.
*  In fact it might make more sense to have an object dealing with I/O be with Selector, rather than a module.

That is how I ended up with the current implementation.

The actual downloading part is done using the same script that Cacher uses to run SmartCache (requestFile.sh).
