### PR TITLE
Reviving input caching (ROOT level)

### DIFF
--- a/PhysicsMod/src/RunLumiSelectionMod.cc
+++ b/PhysicsMod/src/RunLumiSelectionMod.cc
@@ -1,6 +1,6 @@
 #include "MitAna/PhysicsMod/interface/RunLumiSelectionMod.h"
-#include <TTree.h>
 #include "MitAna/DataTree/interface/Names.h"
+#include "MitAna/DataTree/interface/EventHeader.h"
 
 using namespace mithep;
 

--- a/PhysicsMod/src/RunSelectionMod.cc
+++ b/PhysicsMod/src/RunSelectionMod.cc
@@ -1,7 +1,7 @@
 #include "MitAna/PhysicsMod/interface/RunSelectionMod.h"
-#include <TFile.h>
-#include <TTree.h>
 #include "MitAna/DataTree/interface/Names.h"
+#include "MitAna/DataTree/interface/EventHeader.h"
+#include "MitAna/DataTree/interface/RunInfo.h"
 
 using namespace mithep;
 

--- a/TAM/BuildFile.xml
+++ b/TAM/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="root"/>
+<use   name="rootgraphics"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/TAM/interface/TAMSelector.h
+++ b/TAM/interface/TAMSelector.h
@@ -4,8 +4,6 @@
 // keep this for compatibility 
 #define TAM_TAMSelector
 
-#include <TTreeCache.h>
-
 #ifndef ROOT_Riostream
 #include <Riostream.h>
 #endif
@@ -73,8 +71,7 @@ protected:
    };
 
    TTree            *fTree;            //!the tree or chain
-   TTreeCache       *fTreeCache;       //!tree cache
-   Int_t             fCacheSize;       //tree cache size
+   Bool_t            fUseReadCache;    //use read cache
 
    THashTable        fBranchTable;     //!table of requested branches
    THashTable        fEventObjs;       //!table of objects available to any mod
@@ -94,6 +91,9 @@ protected:
    UInt_t            fObjCounterRun;   //!keep object counter for resetting it 
                                        // in process when end of run is reached
    UInt_t            fVerbosity;       //if one wants to print debug info
+
+   TString           fPerfStatsFileName; // file name for tree read performance study
+
    BranchProxy       fProxy;           //proxy for reference resolving branch 
                                        // loading via TAM
    Bool_t            fDoProxy;         //if TAMSelector should be proxy for 
@@ -157,10 +157,11 @@ public:
    void              ReqBranch(const Char_t* bname, T*& address);
    virtual TObject  *RemoveObjThisEvt(const Char_t* name);
    virtual TObject  *RetractObj(const Char_t* name);
-   void              SetCacheSize(Int_t i)      { fCacheSize = i;     }
-   void              SetDoProxy(Bool_t b)       { fDoProxy = b;       }
-   void              SetDoObjTabClean(Bool_t b) { fDoObjTabClean = b; }
-   void              SetVerbosity(UInt_t vb)    { fVerbosity = vb;    }
+   void              SetUseReadCache(Bool_t use){ fUseReadCache = use; }
+   void              SetDoProxy(Bool_t b)       { fDoProxy = b;        }
+   void              SetDoObjTabClean(Bool_t b) { fDoObjTabClean = b;  }
+   void              SetVerbosity(UInt_t vb)    { fVerbosity = vb;     }
+   void              SetPerfStatsFileName(Char_t const* name) { fPerfStatsFileName = name; }
    void              SlaveBegin(TTree* tree);
    void              SlaveTerminate();
    void              Terminate();

--- a/TreeMod/interface/Analysis.h
+++ b/TreeMod/interface/Analysis.h
@@ -79,7 +79,7 @@ namespace mithep
       Bool_t                    Run(Bool_t browse);
       void                      SetAllEvtHdrBrn(const char *n)      { fAllEvtHdrBrn   = n;        }
       void                      SetAllEvtTreeName(const char *n)    { fAllEvtTreeName = n;        }
-      void                      SetCacheSize(Int_t cache)           { fCacheSize      = cache;    }
+      void                      SetUseReadCache(Bool_t use)         { fUseReadCache   = use;      }
       void                      SetCompressionLevel(Int_t level)    { fCompLevel      = level;    }
       void                      SetConfigName(const char* name)     { fConfig         = name;     }
       void                      SetDoObjTabClean(Bool_t b)          { fDoObjTabClean  = b;        }
@@ -107,6 +107,7 @@ namespace mithep
       void                      SetUseMC(Bool_t mc)                 { fUseMC     = mc;            }
       void                      SetUseProof(Bool_t up)              { fUseProof  = up;            }
       void                      SetUseCacher(Int_t i)               { fUseCacher = i;             }
+      void                      SetPerfStatsFileName(char const* n) { fPerfStatsFileName = n;     }
       void                      Terminate();
 
       void                      PrintModuleTree() const; // for debugging
@@ -155,7 +156,7 @@ namespace mithep
       Long64_t                  fDoNEvents;       //events to process (def=TChain::kBigNumber)
       Long64_t                  fSkipNEvents;     //number of events to skip from beginning (def=0)
       UInt_t                    fPrintScale;      //scale for evt number/timings printouts (def=100)
-      Int_t                     fCacheSize;       //size of read cache for events tree
+      Bool_t                    fUseReadCache;    //use TTreeCache to prefetch all branches
       TString                   fTreeName;        //name of trees or friend trees
       TString                   fEvtHdrName;      //name of event header branch
       TString                   fRunTreeName;     //name of run info tree
@@ -167,6 +168,7 @@ namespace mithep
       TString                   fAllEvtTreeName;  //name of all-event tree
       TString                   fHLTObjsName;     //trigger objects branch name
       TString                   fMCEventInfoName; //name of MC event info
+      TString                   fPerfStatsFileName; //file name of TTree read performance study
 
     ClassDef(Analysis, 1) // Top-level analysis class 
   };

--- a/TreeMod/interface/Selector.h
+++ b/TreeMod/interface/Selector.h
@@ -9,21 +9,18 @@
 #ifndef MITANA_TREEMOD_SELECTOR_H
 #define MITANA_TREEMOD_SELECTOR_H
 
-#include "MitAna/TAM/interface/TAModule.h" 
 #include "MitAna/TAM/interface/TAMSelector.h" 
-#include "MitAna/TAM/interface/TAMVirtualBranchLoader.h" 
-#include "MitAna/DataUtil/interface/Cacher.h" 
 #include "MitAna/DataCont/interface/BaseCollection.h"
 #include "MitAna/DataCont/interface/ObjArray.h"
-#include "MitAna/DataTree/interface/EventHeader.h" 
-#include "MitAna/DataTree/interface/LAHeader.h" 
-#include "MitAna/DataTree/interface/RunInfo.h" 
-#include "MitAna/DataTree/interface/MCRunInfo.h" 
 
-#include <typeindex>
+#include <vector>
 
 namespace mithep {
   class OutputMod;
+  class Cacher;
+  class EventHeader;
+  class RunInfo;
+  class MCRunInfo;
 
   class Selector : public TAMSelector {
   public:
@@ -137,30 +134,17 @@ namespace mithep {
     EventHeader*         fEventHeader;    //!event header for current event
     RunInfo*             fRunInfo;        //!run information for current run
     MCRunInfo*           fMCRunInfo;      //!MC run information for current run
-    TTree*               fLATree;         //!look-ahead tree in current file
-    LAHeader*            fLAHeader;       //!event header for next event
     UInt_t               fCurRunNum;      //!current run number
     TList                fOutputMods;     //!pointer(s) to output modules
     TObjArray            fTrash;          //!pointers to trashed objects
     THashTable           fObjInfoStore;   //!single-point pointer store for GetObject function
+    std::vector<Long64_t> fRunTransitions; //(local) entry number for the last events of runs
 
   private:
     friend class OutputMod;
 
     ClassDef(Selector, 1) // Customized selector class
   };
-}
-
-//--------------------------------------------------------------------------------------------------
-inline Bool_t mithep::Selector::ConsistentRunNum() const
-{
-  return (ValidRunNum() && fCurRunNum==fEventHeader->RunNum());
-}
-
-//--------------------------------------------------------------------------------------------------
-inline Bool_t mithep::Selector::ValidRunInfo() const
-{
-  return (fRunInfo && fCurRunNum==fRunInfo->RunNum());
 }
 
 namespace mithep {

--- a/TreeMod/src/CatalogingMod.cc
+++ b/TreeMod/src/CatalogingMod.cc
@@ -1,6 +1,7 @@
 #include <TFile.h>
 #include <TTree.h>
 #include "MitAna/DataTree/interface/Names.h"
+#include "MitAna/DataTree/interface/RunInfo.h"
 #include "MitAna/DataUtil/interface/Debug.h"
 #include "MitAna/TreeMod/interface/CatalogingMod.h"
 

--- a/TreeMod/src/HLTFwkMod.cc
+++ b/TreeMod/src/HLTFwkMod.cc
@@ -6,6 +6,7 @@
 #include "MitAna/DataTree/interface/TriggerObjectBaseCol.h"
 #include "MitAna/DataTree/interface/TriggerObjectRelCol.h"
 #include "MitAna/DataTree/interface/TriggerObjectCol.h"
+#include "MitAna/DataTree/interface/RunInfo.h"
 
 using namespace mithep;
 

--- a/TreeMod/src/HLTMod.cc
+++ b/TreeMod/src/HLTMod.cc
@@ -5,6 +5,7 @@
 #include "MitAna/DataTree/interface/TriggerObject.h"
 #include "MitAna/DataTree/interface/TriggerObjectCol.h"
 #include "MitAna/DataTree/interface/TriggerObjectsTable.h"
+#include "MitAna/DataTree/interface/EventHeader.h"
 
 using namespace mithep;
 

--- a/TreeMod/src/MCFwkMod.cc
+++ b/TreeMod/src/MCFwkMod.cc
@@ -1,6 +1,7 @@
 #include "MitAna/TreeMod/interface/MCFwkMod.h"
 
 #include "MitAna/DataTree/interface/MCRunInfo.h"
+#include "MitAna/DataTree/interface/EventHeader.h"
 #include "MitAna/DataTree/interface/Names.h"
 
 ClassImp(mithep::MCFwkMod)

--- a/TreeMod/src/OutputMod.cc
+++ b/TreeMod/src/OutputMod.cc
@@ -4,6 +4,8 @@
 #include "MitAna/DataTree/interface/BranchTable.h"
 #include "MitAna/DataTree/interface/EventHeaderCol.h"
 #include "MitAna/DataTree/interface/MCEventInfo.h"
+#include "MitAna/DataTree/interface/LAHeader.h"
+#include "MitAna/DataTree/interface/RunInfo.h"
 #include "MitAna/TreeMod/interface/TreeBranchLoader.h"
 #include "MitAna/TreeMod/interface/OutputMod.h"
 #include "MitAna/TreeMod/interface/HLTFwkMod.h"

--- a/bin/analysis.py
+++ b/bin/analysis.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import re
+import ROOT
 
 if __name__ == '__main__':
     from argparse import ArgumentParser
@@ -109,5 +110,5 @@ if __name__ == '__main__':
     print '\n+++++ ANALYSIS FLOW +++++\n'
     analysis.PrintModuleTree()
     print '\n+++++++++++++++++++++++++\n'
-    
+
     analysis.Run(False)

--- a/bin/runOnDatasets.py
+++ b/bin/runOnDatasets.py
@@ -10,7 +10,7 @@ import shutil
 import socket
 
 # experimental full local caching
-FULL_LOCAL = False
+FULL_LOCAL = True
 
 #######################
 ## UTILITY FUNCTIONS ##


### PR DESCRIPTION
We had a functionality of using TTreeCache, but the implementation was somewhat peculiar (and also would cause segfaults because it would access a null pointer).
Since there is no need to own the cache object (TFile internally holds it), I removed the fTreeCache member from TAMSelector. Also the cache size member variable was removed, since whatever you set it to, the maximum cache size is limited to the size of the chunks used when writing the bambu files (default 30MB - might want to increase it in future versions).

Another change is in the "look-ahead" tree, which is used only to detect the run transition. (In my opinion this mechanism, in which we write an entire tree for just recording the run number of each event, is a bit wasteful, so perhaps we can change the way we do this detection in the future versions.) Instead of reading the look-ahead tree as we process the events, we now read the entire tree when opening a new file, and save the entry numbers when the transition happens. This way we have slightly less jumps in the read positions within the files.

The rest of the updates are coming from slimming down the include list in Selector.h.