### PR TITLE
Adding utility modules RunLumiListMod and BooleanMod

### DIFF
--- a/PhysicsMod/dict/MitAnaPhysicsModLinkDef.h
+++ b/PhysicsMod/dict/MitAnaPhysicsModLinkDef.h
@@ -5,6 +5,7 @@
 #include "MitAna/PhysicsMod/interface/HLTExampleMod.h"
 #include "MitAna/PhysicsMod/interface/RunSelectionMod.h"
 #include "MitAna/PhysicsMod/interface/RunLumiSelectionMod.h"
+#include "MitAna/PhysicsMod/interface/RunLumiListMod.h"
 #include "MitAna/PhysicsMod/interface/SimpleExampleMod.h"
 #include "MitAna/PhysicsMod/interface/TrackToPartMod.h"
 #include "MitAna/PhysicsMod/interface/MCProcessSelectionMod.h"
@@ -27,6 +28,7 @@
 #pragma link C++ class mithep::TrackToPartMod+;
 #pragma link C++ class mithep::RunSelectionMod+;
 #pragma link C++ class mithep::RunLumiSelectionMod+;
+#pragma link C++ class mithep::RunLumiListMod+;
 #pragma link C++ class mithep::MCProcessSelectionMod+;
 #pragma link C++ class mithep::FastJetMod+;
 #pragma link C++ class mithep::MaskCollectionMod+;

--- a/PhysicsMod/interface/RunLumiListMod.h
+++ b/PhysicsMod/interface/RunLumiListMod.h
@@ -1,0 +1,37 @@
+//--------------------------------------------------------------------------------------------------
+// RunLumiListMod
+//
+// This module is used to extract the run & lumi numbers the module runs over. The output is in the
+// form of a tree, which should be merged later by a script.
+//
+// Authors: Y.Iiyama
+//--------------------------------------------------------------------------------------------------
+
+#ifndef MITANA_PHYSICSMOD_RUNLUMILISTMOD_H
+#define MITANA_PHYSICSMOD_RUNLUMILISTMOD_H
+
+#include "MitAna/TreeMod/interface/BaseMod.h"
+
+namespace mithep {
+
+  class RunLumiListMod : public BaseMod {
+  public:
+    RunLumiListMod(char const* name = "RunLumiListMod", char const* title = "RunLumiListMod") : BaseMod(name, title) {}
+    ~RunLumiListMod() {}
+
+  private:
+    void Process() override;
+    void SlaveBegin() override;
+    void SlaveTerminate() override;
+
+    TTree* fListTree{};
+    UInt_t fRunNumber{};
+    UInt_t fLumiNumber{};
+    UInt_t fNEvents{};
+
+    ClassDef(RunLumiListMod, 0)
+  };
+
+}
+
+#endif

--- a/PhysicsMod/src/RunLumiListMod.cc
+++ b/PhysicsMod/src/RunLumiListMod.cc
@@ -1,0 +1,42 @@
+#include "MitAna/PhysicsMod/interface/RunLumiListMod.h"
+
+#include "MitAna/DataTree/interface/EventHeader.h"
+
+ClassImp(mithep::RunLumiListMod)
+
+void
+mithep::RunLumiListMod::Process()
+{
+  auto* header = GetEventHeader();
+  UInt_t run = header->RunNum();
+  UInt_t lumi = header->LumiSec();
+
+  if (run != fRunNumber || lumi != fLumiNumber) {
+    if (fRunNumber != 0)
+      fListTree->Fill();
+
+    fRunNumber = run;
+    fLumiNumber = lumi;
+    fNEvents = 0;
+  }
+
+  ++fNEvents;
+}
+
+void
+mithep::RunLumiListMod::SlaveBegin()
+{
+  fListTree = new TTree("RunLumiList", "RunLumiList");
+  fListTree->Branch("run", &fRunNumber, "run/i");
+  fListTree->Branch("lumi", &fLumiNumber, "lumi/i");
+  fListTree->Branch("nevents", &fNEvents, "nevents/i");
+
+  AddOutput(fListTree);
+}
+
+void
+mithep::RunLumiListMod::SlaveTerminate()
+{
+  if (fRunNumber != 0)
+    fListTree->Fill();
+}

--- a/TreeMod/dict/MitAnaTreeModLinkDef.h
+++ b/TreeMod/dict/MitAnaTreeModLinkDef.h
@@ -9,6 +9,7 @@
 #include "MitAna/TreeMod/interface/MCFwkMod.h"
 #include "MitAna/TreeMod/interface/HLTMod.h"
 #include "MitAna/TreeMod/interface/L1Mod.h"
+#include "MitAna/TreeMod/interface/BooleanMod.h"
 #include "MitAna/TreeMod/interface/OutputMod.h"
 #include "MitAna/TreeMod/interface/Selector.h"
 #include "MitAna/TreeMod/interface/TreeBranchLoader.h"
@@ -32,6 +33,8 @@
 #pragma link C++ class mithep::MCFwkMod+;
 #pragma link C++ class mithep::HLTMod+;
 #pragma link C++ class mithep::L1Mod+;
+#pragma link C++ class mithep::BooleanMod+;
+#pragma link C++ class mithep::BooleanMod::Expression+;
 #pragma link C++ class mithep::OutputMod+;
 #pragma link C++ class mithep::Selector+;
 #pragma link C++ class mithep::TreeBranchLoader+;

--- a/TreeMod/interface/BooleanMod.h
+++ b/TreeMod/interface/BooleanMod.h
@@ -1,0 +1,61 @@
+#ifndef MITANA_TREEMOD_BOOLEANMOD_H
+#define MITANA_TREEMOD_BOOLEANMOD_H
+
+#include "MitAna/TreeMod/interface/BaseMod.h"
+
+namespace mithep {
+
+  class BooleanMod : public BaseMod {
+  public:
+    class Expression : public TObject {
+    public:
+      enum Operator {
+        kPASS,
+        kNOT,
+        kAND,
+        kOR
+      };
+
+      Expression(BaseMod const*, Operator = kPASS);
+      Expression(Expression const*, Operator);
+      Expression(BaseMod const*, BaseMod const*, Operator);
+      Expression(BaseMod const*, Expression const*, Operator);
+      Expression(Expression const*, BaseMod const*, Operator);
+      Expression(Expression const*, Expression const*, Operator);
+
+      Expression(Expression const&);
+      ~Expression();
+
+      Expression& operator=(Expression const&);
+
+      Bool_t Eval() const;
+
+    private:
+      Operator fOperator{kPASS};
+      BaseMod const* fMod{0};
+      Expression const* fExpr[2] = {0, 0};
+      Bool_t fMustDelete[2] = {kFALSE, kFALSE};
+
+      ClassDef(Expression, 0)
+    };
+
+    BooleanMod(char const* name = "BooleanMod", char const* title = "boolean operation") : BaseMod(name, title) {}
+    ~BooleanMod() {}
+
+    void SetExpression(Expression const* expr) { fExpression = expr; }
+
+  private:
+    void Process() override
+    {
+      if (!fExpression || !fExpression->Eval())
+        SkipEvent();
+    }
+
+    Expression const* fExpression{0};
+
+    ClassDef(BooleanMod, 0)
+  };
+
+}
+
+#endif

--- a/TreeMod/interface/BooleanMod.h
+++ b/TreeMod/interface/BooleanMod.h
@@ -3,6 +3,8 @@
 
 #include "MitAna/TreeMod/interface/BaseMod.h"
 
+#include "TH1D.h"
+
 namespace mithep {
 
   class BooleanMod : public BaseMod {
@@ -30,6 +32,8 @@ namespace mithep {
 
       Bool_t Eval() const;
 
+      std::vector<BaseMod const*> GetMods() const;
+
     private:
       Operator fOperator{kPASS};
       BaseMod const* fMod{0};
@@ -45,13 +49,13 @@ namespace mithep {
     void SetExpression(Expression const* expr) { fExpression = expr; }
 
   private:
-    void Process() override
-    {
-      if (!fExpression || !fExpression->Eval())
-        SkipEvent();
-    }
+    void Process() override;
+    void SlaveBegin() override;
 
     Expression const* fExpression{0};
+
+    TH1D* fCounter{0};
+    std::vector<BaseMod const*> fMods{};
 
     ClassDef(BooleanMod, 0)
   };

--- a/TreeMod/src/BooleanMod.cc
+++ b/TreeMod/src/BooleanMod.cc
@@ -1,0 +1,131 @@
+#include "MitAna/TreeMod/interface/BooleanMod.h"
+
+#include <stdexcept>
+
+using namespace mithep;
+
+ClassImp(mithep::BooleanMod)
+ClassImp(mithep::BooleanMod::Expression)
+
+BooleanMod::Expression::Expression(BaseMod const* mod, Operator optr/* = kPASS*/) :
+  fOperator(optr),
+  fMod(mod)
+{
+  if (fOperator != kPASS && fOperator != kNOT)
+    throw std::runtime_error("Binary operator for a single operand");
+}
+
+BooleanMod::Expression::Expression(Expression const* expr1, Operator optr) :
+  fOperator(optr),
+  fExpr{expr1, 0}
+{
+  if (fOperator != kPASS && fOperator != kNOT)
+    throw std::runtime_error("Binary operator for a single operand");
+}
+
+BooleanMod::Expression::Expression(BaseMod const* mod1, BaseMod const* mod2, Operator optr) :
+  fOperator(optr)
+{
+  if (fOperator == kPASS || fOperator == kNOT)
+    throw std::runtime_error("Unary operator for a two operands");
+
+  fExpr[0] = new Expression(mod1);
+  fExpr[1] = new Expression(mod2);
+  fMustDelete[0] = fMustDelete[1] = kTRUE;
+}
+
+BooleanMod::Expression::Expression(BaseMod const* mod1, Expression const* expr2, Operator optr) :
+  fOperator(optr),
+  fExpr{0, expr2}
+{
+  if (fOperator == kPASS || fOperator == kNOT)
+    throw std::runtime_error("Unary operator for a two operands");
+
+  fExpr[0] = new Expression(mod1);
+  fMustDelete[0] = kTRUE;
+}
+
+BooleanMod::Expression::Expression(Expression const* expr1, BaseMod const* mod2, Operator optr) :
+  fOperator(optr),
+  fExpr{expr1, 0}
+{
+  if (fOperator == kPASS || fOperator == kNOT)
+    throw std::runtime_error("Unary operator for a two operands");
+
+  fExpr[1] =new Expression(mod2);
+  fMustDelete[1] = kTRUE;
+}
+
+BooleanMod::Expression::Expression(Expression const* expr1, Expression const* expr2, Operator optr) :
+  fOperator(optr),
+  fExpr{expr1, expr2}
+{
+  if (fOperator == kPASS || fOperator == kNOT)
+    throw std::runtime_error("Unary operator for a two operands");
+}
+
+BooleanMod::Expression::Expression(Expression const& orig) :
+  fOperator(orig.fOperator),
+  fMod(orig.fMod),
+  fExpr{orig.fExpr[0], orig.fExpr[1]}
+{
+}
+
+BooleanMod::Expression::~Expression()
+{
+  for (unsigned iE = 0; iE != 2; ++iE) {
+    if (fExpr[iE] && fMustDelete[iE])
+      delete fExpr[iE];
+  }
+}
+
+BooleanMod::Expression&
+BooleanMod::Expression::operator=(Expression const& rhs)
+{
+  for (unsigned iE = 0; iE != 2; ++iE) {
+    if (fExpr[iE] && fMustDelete[iE])
+      delete fExpr[iE];
+  }
+
+  fOperator = rhs.fOperator;
+  fMod = rhs.fMod;
+  fExpr[0] = rhs.fExpr[0];
+  fExpr[1] = rhs.fExpr[1];
+  fMustDelete[0] = kFALSE;
+  fMustDelete[1] = kFALSE;
+
+  return *this;
+}
+
+Bool_t
+BooleanMod::Expression::Eval() const
+{
+  if (fMod) {
+    if (fOperator == kPASS)
+      return fMod->IsActive();
+    else if (fOperator == kNOT)
+      return !fMod->IsActive();
+    else
+      return kFALSE;
+  }
+
+  if (fExpr[0] && !fExpr[1]) {
+    if (fOperator == kPASS)
+      return fExpr[0]->Eval();
+    else if (fOperator == kNOT)
+      return !fExpr[0]->Eval();
+    else
+      return kFALSE;
+  }
+
+  if (fExpr[0] && fExpr[1]) {
+    if (fOperator == kAND)
+      return fExpr[0]->Eval() && fExpr[1]->Eval();
+    else if (fOperator == kOR)
+      return fExpr[0]->Eval() || fExpr[1]->Eval();
+    else
+      return kFALSE;
+  }
+
+  return kFALSE;
+}

--- a/bin/makeJson.py
+++ b/bin/makeJson.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+#-------------------------------------------------------------------------------
+# makeJson.py
+#
+# This script is used to make a lumi list JSON file out of the output from
+# the RunLumiListMod.
+# Usage: makeJson.py <ROOT file> [<ROOT file2> ...]
+# Wildcard * is allowed for the ROOT file path specification.
+#
+#-------------------------------------------------------------------------------
+
+import sys
+import array
+from argparse import ArgumentParser
+import ROOT
+ROOT.gROOT.SetBatch(True)
+
+argParser = ArgumentParser(description = 'Make JSON lumi list')
+argParser.add_argument('paths', metavar = 'PATH', nargs = '+', help = 'Paths to ROOT files (wildcard allowed) containing lumi list trees.')
+argParser.add_argument('--out', '-o', metavar = 'FILE', dest = 'outputFile', default = 'lumis.txt', help = 'Output file name.')
+
+args = argParser.parse_args()
+sys.argv = []
+
+source = ROOT.TChain('RunLumiList')
+for path in args.paths:
+    source.Add(path)
+
+run = array.array('I', [0])
+lumi = array.array('I', [0])
+
+source.SetBranchAddress('run', run)
+source.SetBranchAddress('lumi', lumi)
+
+allLumis = {}
+
+iEntry = 0
+while source.GetEntry(iEntry) > 0:
+    iEntry += 1
+
+    if run[0] not in allLumis:
+        allLumis[run[0]] = []
+        
+    lumis = allLumis[run[0]]
+
+    if lumi[0] not in lumis:
+        lumis.append(lumi[0])
+
+text = ''
+for run in sorted(allLumis.keys()):
+    text += '  "%d": [\n' % run
+
+    current = -1
+    for lumi in sorted(allLumis[run]):
+        if lumi == current + 1:
+            current = lumi
+            continue
+
+        if current > 0:
+            text += '%d],\n' % current
+
+        current = lumi
+        text += '    [%d, ' % current
+
+    text += '%d]\n' % current
+    text += '  ],\n'
+
+with open(args.outputFile, 'w') as json:
+    json.write('{\n' + text[:-2] + '\n}')

--- a/macros/listLumi.py
+++ b/macros/listLumi.py
@@ -1,0 +1,7 @@
+from MitAna.TreeMod.bambu import mithep, analysis
+
+listMod = mithep.RunLumiListMod()
+
+# RunLumiSelectionMod will be applied automatically from the command-line option to analysis.py / runOnDatasets.py
+
+analysis.setSequence(listMod)


### PR DESCRIPTION
RunLumiListMod is not for real analysis but is to create a TTree that contains the run & lum info of the files that are processed. The result can be written out in the JSON format using bin/makeJson.py and can be fed to brilCalc, which would then give us the exact integrated luminosity that went into a given job.
A sample job configuration for using the RunLumiListMod can be found at macros/listLumi.py.

BooleanMod can be used to facilitate the job sequence construction. Filtering modules (those that issue SkipEvent) can be combined in an "expression" that bonds them with AND and OR, or inverts the decision (NOT), and the value of this expression for the event is used to veto or pass the event. Essentially arbitrary sequence can be formulated by combining the BooleanMods.