### PR TITLE
fixing a stupid bug (forgot parenthesis)

### DIFF
--- a/PhysicsUtils/src/Bins.cc
+++ b/PhysicsUtils/src/Bins.cc
@@ -31,8 +31,10 @@ Bins::getBin(int nBins, double bins[], double value, double* x0, double* x1)
     return -1;
 
   if (value > bins[nBins]) {
-    *x0 = bins[nBins - 1];
-    *x1 = bins[nBins];
+    if (x0)
+      *x0 = bins[nBins - 1];
+    if (x1)
+      *x1 = bins[nBins];
     return nBins - 1;
   }
 
@@ -54,7 +56,7 @@ void
 Bins::getBins_int(int nBins_total, double* Lower, double xmin, double xmax, bool plotLog)
 {
   int nBins = nBins_total - 1;
-  double dx = plotLog ? TMath::Power(xmax / xmin, 1. / nBins) : xmax - xmin / nBins;
+  double dx = plotLog ? TMath::Power(xmax / xmin, 1. / nBins) : (xmax - xmin) / nBins;
 
   double lowerExact = xmin;
   Lower[0] = TMath::Ceil(lowerExact);

--- a/PhysicsUtils/src/QGTagger.cc
+++ b/PhysicsUtils/src/QGTagger.cc
@@ -15,7 +15,7 @@ QGTagger::QGTagger(bool useCHS)
 
 QGTagger::~QGTagger()
 {
-  // Destructor.
+  delete qgLikelihood_;
 }
 
 double


### PR DESCRIPTION
A forgotten pair of parenthesis was giving a very different result for quark-gluon tagging.