### PR TITLE
HLTMod: Adding an option to not process TriggerObjects (i.e. work as a simple HLT filter)

### DIFF
--- a/TreeMod/interface/HLTMod.h
+++ b/TreeMod/interface/HLTMod.h
@@ -56,6 +56,7 @@ namespace mithep
     Int_t       GetNFailed() const      { return fNFailed;       }
 
     void AddTrigger(const char *expr, UInt_t firstRun = 0, UInt_t lastRun = 0);
+    void SetExportTrigObjects(Bool_t b)  { fExportTrigObjects = b; }
     void SetAbortIfNotAccepted(Bool_t b) { fAbortIfNotAccepted = b; }
     void SetAbortIfNoData(Bool_t b)      { fAbortIfNoData = b; }
     void SetBitsName(const char *n)      { fBitsName = n; }
@@ -78,6 +79,7 @@ namespace mithep
     typedef std::pair<TString, RunRange> TriggerNameWithValidity;
     typedef std::vector<TriggerNameWithValidity> TriggerNames;
 
+    Bool_t       fExportTrigObjects{kTRUE};
     Bool_t       fAbortIfNotAccepted{kTRUE};
     Bool_t       fAbortIfNoData{kTRUE}; //set to false for e.g. private MC with no HLT info
     Bool_t       fPrintTable{kFALSE};    //=true then print HLT trigger table in BeginRun


### PR DESCRIPTION
HLTMod is great in that it can collect the trigger object collection of the given trigger for you, but it collects those from all filters. This means that when you do trigger object matching, you may end up with matching your offline object to e.g. just an L1 seed. If we want to match to the trigger objects from a specific HLT filter, such as the last filter of a path, there is no way around other than to actually know the filter name and pick out the objects from the filter by hand. In such cases, the object collection exported by the HLTMod is wasted, and so it makes sense to be able to turn off this feature.