### PR TITLE
adding new features to physics modules

### DIFF
--- a/DataUtil/src/Cacher.cc
+++ b/DataUtil/src/Cacher.cc
@@ -161,10 +161,11 @@ Bool_t Cacher::SubmitCacheRequest(const char* file, Bool_t initial) const
                +TString(file);
 
   if (fFullLocal) {
-    if (initial)
-      cmd += " -L"; // make a symbolic link under ./store/...
-    else
-      cmd += " -C"; // copy the file over to ./store/...
+    // if (initial)
+    //   cmd += " -L"; // make a symbolic link under ./store/...
+    // else
+    //   cmd += " -C"; // copy the file over to ./store/...
+    cmd += " -C";
   }
 
   // Execute the system command

--- a/PhysicsMod/dict/TemplateModsLinkDef.h
+++ b/PhysicsMod/dict/TemplateModsLinkDef.h
@@ -20,6 +20,7 @@
 #pragma link C++ class mithep::FilterMod<mithep::GenJet>+;
 #pragma link C++ class mithep::FilterMod<mithep::Jet>+;
 #pragma link C++ class mithep::FilterMod<mithep::MCParticle>+;
+#pragma link C++ class mithep::FilterMod<mithep::PFCandidate>+;
 #pragma link C++ class mithep::FilterMod<mithep::Met>+;
 #pragma link C++ class mithep::FilterMod<mithep::Muon>+;
 #pragma link C++ class mithep::FilterMod<mithep::PFJet>+;
@@ -39,6 +40,7 @@
 #pragma link C++ typedef mithep::GenJetFilterMod;
 #pragma link C++ typedef mithep::JetFilterMod;
 #pragma link C++ typedef mithep::MCParticleFilterMod;
+#pragma link C++ typedef mithep::PFCandidateFilterMod;
 #pragma link C++ typedef mithep::MetFilterMod;
 #pragma link C++ typedef mithep::MuonFilterMod;
 #pragma link C++ typedef mithep::PFJetFilterMod;

--- a/PhysicsMod/interface/TemplateMods.h
+++ b/PhysicsMod/interface/TemplateMods.h
@@ -46,6 +46,7 @@ namespace mithep {
   typedef FilterMod<GenJet> GenJetFilterMod;
   typedef FilterMod<Jet> JetFilterMod;
   typedef FilterMod<MCParticle> MCParticleFilterMod;
+  typedef FilterMod<PFCandidate> PFCandidateFilterMod;
   typedef FilterMod<Met> MetFilterMod;
   typedef FilterMod<Muon> MuonFilterMod;
   typedef FilterMod<PFJet> PFJetFilterMod;

--- a/PhysicsMod/src/FilterMod.cc
+++ b/PhysicsMod/src/FilterMod.cc
@@ -1,5 +1,34 @@
 #include "MitAna/PhysicsMod/interface/FilterMod.h"
+#include "MitAna/DataTree/interface/PFCandidate.h"
+#include "MitAna/DataTree/interface/MCParticle.h"
+#include <algorithm>
 
 using namespace mithep;
 
 templateClassImp(mithep::FilterMod)
+
+template<>
+Bool_t
+mithep::FilterMod<mithep::PFCandidate, mithep::PFCandidate>::IsAllowedParticleId(mithep::PFCandidate const& part) const
+{
+  if (fParticleIds.size() == 0)
+    return true;
+
+  int id = part.PFType();
+  if (part.Charge() < 0.)
+    id *= -1;
+
+  bool inlist = std::binary_search(fParticleIds.begin(), fParticleIds.end(), id);
+  return fVetoParticleId ? !inlist : inlist;
+}
+
+template<>
+Bool_t
+mithep::FilterMod<mithep::MCParticle, mithep::MCParticle>::IsAllowedParticleId(mithep::MCParticle const& part) const
+{
+  if (fParticleIds.size() == 0)
+    return true;
+
+  bool inlist = std::binary_search(fParticleIds.begin(), fParticleIds.end(), part.PdgId());
+  return fVetoParticleId ? !inlist : inlist;
+}

--- a/bin/setupExternal.sh
+++ b/bin/setupExternal.sh
@@ -13,7 +13,7 @@
 #
 # PACKAGES TO INSTALL
 #PACKAGES="fastjet fastjet-contrib qjets"
-PACKAGES="qjets"
+PACKAGES="qjets pwhg_cphto_reweight"
 
 # SPECIFIC PARAMETERS
 FJ_VERSION="3.1.0-odfocd"
@@ -154,6 +154,32 @@ install-qjets() {
   scram setup qjets
 }
 
+install-pwhg_cphto_reweight() {
+  # add local fastjet external to scarm config
+
+  local BASE=$(find-external pwhg_cphto_reweight)
+  local TARGET=$CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/pwhg_cphto_reweight.xml
+
+  echo ""
+  echo " INFO - using pwhg_cphto_reweight at: $BASE"
+  echo ""
+
+  mv $TARGET ${TARGET}-last.$(date +%s) 2> /dev/null
+
+  echo \
+'  <tool name="pwhg_cphto_reweight" version="1">
+    <lib name="cphto"/>
+    <client>
+      <environment name="LIBDIR" default="'$BASE'"/>
+    </client>
+  </tool>
+' > $TARGET
+
+  # commit the scram config changes
+  cd $CMSSW_BASE/src
+  scram setup pwhg_cphto_reweight
+}
+
 ### Loop over PACKAGES
 
 for PACKAGE in $PACKAGES
@@ -167,6 +193,9 @@ do
       ;;
     qjets)
       install-qjets $FJ_VERSION
+      ;;
+    pwhg_cphto_reweight)
+      install-pwhg_cphto_reweight
       ;;
     *)
       echo "Unknown external $PACKAGE"


### PR DESCRIPTION
* Reworked FastJetMod so that we can recluster PFJets and GenJets.
* Added an option in the FilterMod (object selector) to filter also on particle ids, in addition to pT and eta. The PID filter only applies to PFCandidates and MCParticles.
* Accidental update on Cacher, which makes all files to be copied to the local disk when the "full-local" flag is on. The flag is off by default, so this basically won't affect anyone.