### PR TITLE
Dataformat for 043

### DIFF
--- a/DataTree/dict/PFTauColLinkDef.h
+++ b/DataTree/dict/PFTauColLinkDef.h
@@ -23,46 +23,18 @@
 #pragma read \
     sourceClass="mithep::PFTau" \
     version="[-7]" \
-    source="Double32_t fDiscriminationByLooseElectronRejection; \
-            Double32_t fDiscriminationByMediumElectronRejection; \
-            Double32_t fDiscriminationByTightElectronRejection; \
-            Double32_t fDiscriminationByLooseMuonRejection; \
-            Double32_t fDiscriminationByMediumMuonRejection; \
-            Double32_t fDiscriminationByTightMuonRejection; \
-            Double32_t fDiscriminationByDecayModeFinding; \
-            Double32_t fDiscriminationByVLooseCombinedIsolationDBSumPtCorr; \
-            Double32_t fDiscriminationByLooseCombinedIsolationDBSumPtCorr; \
-            Double32_t fDiscriminationByMediumCombinedIsolationDBSumPtCorr; \
-            Double32_t fDiscriminationByTightCombinedIsolationDBSumPtCorr; \
-            Double32_t fDiscriminationByRawCombinedIsolationDBSumPtCorr; \
+    source="Double32_t fDiscriminationByDecayModeFinding; \
             Double32_t fLooseCombinedIsolationDBSumPtCorr3Hits; \
             Double32_t fMediumCombinedIsolationDBSumPtCorr3Hits; \
             Double32_t fTightCombinedIsolationDBSumPtCorr3Hits; \
-            Double32_t fRawCombinedIsolationDBSumPtCorr3Hits; \
-            Double32_t fLooseMuonRejection2; \
-            Double32_t fMediumMuonRejection2; \
-            Double32_t fTightMuonRejection2;" \
+            Double32_t fRawCombinedIsolationDBSumPtCorr3Hits;" \
     targetClass="mithep::PFTau" \
     target="fPFTauDiscriminator" \
-    code="{ fPFTauDiscriminator[mithep::PFTau::kDiscriminationByLooseElectronRejection] = onfile.fDiscriminationByLooseElectronRejection; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByMediumElectronRejection] = onfile.fDiscriminationByMediumElectronRejection; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByTightElectronRejection] = onfile.fDiscriminationByTightElectronRejection; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByLooseMuonRejection] = onfile.fDiscriminationByLooseMuonRejection; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByMediumMuonRejection] = onfile.fDiscriminationByMediumMuonRejection; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByTightMuonRejection] = onfile.fDiscriminationByTightMuonRejection; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByDecayModeFinding] = onfile.fDiscriminationByDecayModeFinding; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByVLooseCombinedIsolationDBSumPtCorr] = onfile.fDiscriminationByVLooseCombinedIsolationDBSumPtCorr; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByLooseCombinedIsolationDBSumPtCorr] = onfile.fDiscriminationByLooseCombinedIsolationDBSumPtCorr; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByMediumCombinedIsolationDBSumPtCorr] = onfile.fDiscriminationByMediumCombinedIsolationDBSumPtCorr; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByTightCombinedIsolationDBSumPtCorr] = onfile.fDiscriminationByTightCombinedIsolationDBSumPtCorr; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByRawCombinedIsolationDBSumPtCorr] = onfile.fDiscriminationByRawCombinedIsolationDBSumPtCorr; \
+    code="{ fPFTauDiscriminator[mithep::PFTau::kDiscriminationByDecayModeFinding] = onfile.fDiscriminationByDecayModeFinding; \
       fPFTauDiscriminator[mithep::PFTau::kDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits] = onfile.fLooseCombinedIsolationDBSumPtCorr3Hits; \
       fPFTauDiscriminator[mithep::PFTau::kDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits] = onfile.fMediumCombinedIsolationDBSumPtCorr3Hits; \
       fPFTauDiscriminator[mithep::PFTau::kDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits] = onfile.fTightCombinedIsolationDBSumPtCorr3Hits; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits] = onfile.fRawCombinedIsolationDBSumPtCorr3Hits; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByLooseMuonRejection2] = onfile.fLooseMuonRejection2; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByMediumMuonRejection2] = onfile.fMediumMuonRejection2; \
-      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByTightMuonRejection2] = onfile.fTightMuonRejection2; }" \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits] = onfile.fRawCombinedIsolationDBSumPtCorr3Hits; }" \
 
 #pragma read \
     sourceClass="mithep::PFTau" \
@@ -84,10 +56,24 @@
             Double32_t fMVA3LooseElectronRejection; \
             Double32_t fMVA3MediumElectronRejection; \
             Double32_t fMVA3TightElectronRejection; \
-            Double32_t fMVA3VTightElectronRejection;" \
+            Double32_t fMVA3VTightElectronRejection; \
+            Double32_t fDiscriminationByLooseElectronRejection; \
+            Double32_t fDiscriminationByMediumElectronRejection; \
+            Double32_t fDiscriminationByTightElectronRejection; \
+            Double32_t fDiscriminationByLooseMuonRejection; \
+            Double32_t fDiscriminationByMediumMuonRejection; \
+            Double32_t fDiscriminationByTightMuonRejection; \
+            Double32_t fDiscriminationByVLooseCombinedIsolationDBSumPtCorr; \
+            Double32_t fDiscriminationByLooseCombinedIsolationDBSumPtCorr; \
+            Double32_t fDiscriminationByMediumCombinedIsolationDBSumPtCorr; \
+            Double32_t fDiscriminationByTightCombinedIsolationDBSumPtCorr; \
+            Double32_t fDiscriminationByRawCombinedIsolationDBSumPtCorr; \
+            Double32_t fLooseMuonRejection2; \
+            Double32_t fMediumMuonRejection2; \
+            Double32_t fTightMuonRejection2;" \
     targetClass="mithep::PFTau" \
     target="fPFTauLegacyDiscriminator" \
-  code="{ unsigned const dOffset = mithep::PFTau::nDiscriminators; \
+    code="{ unsigned const dOffset = mithep::PFTau::nDiscriminators; \
       fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationAgainstElectron - dOffset] = onfile.fDiscriminationAgainstElectron; \
       fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationAgainstMuon - dOffset] = onfile.fDiscriminationAgainstMuon; \
       fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByMVAElectronRejection - dOffset] = onfile.fDiscriminationByMVAElectronRejection; \
@@ -105,7 +91,92 @@
       fPFTauLegacyDiscriminator[mithep::PFTau::kMVA3LooseElectronRejection - dOffset] = onfile.fMVA3LooseElectronRejection; \
       fPFTauLegacyDiscriminator[mithep::PFTau::kMVA3MediumElectronRejection - dOffset] = onfile.fMVA3MediumElectronRejection; \
       fPFTauLegacyDiscriminator[mithep::PFTau::kMVA3TightElectronRejection - dOffset] = onfile.fMVA3TightElectronRejection; \
-      fPFTauLegacyDiscriminator[mithep::PFTau::kMVA3VTightElectronRejection - dOffset] = onfile.fMVA3VTightElectronRejection; }" \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kMVA3VTightElectronRejection - dOffset] = onfile.fMVA3VTightElectronRejection; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByLooseElectronRejection - dOffset] = onfile.fDiscriminationByLooseElectronRejection; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByMediumElectronRejection - dOffset] = onfile.fDiscriminationByMediumElectronRejection; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByTightElectronRejection - dOffset] = onfile.fDiscriminationByTightElectronRejection; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByLooseMuonRejection - dOffset] = onfile.fDiscriminationByLooseMuonRejection; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByMediumMuonRejection - dOffset] = onfile.fDiscriminationByMediumMuonRejection; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByTightMuonRejection - dOffset] = onfile.fDiscriminationByTightMuonRejection; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByVLooseCombinedIsolationDBSumPtCorr - dOffset] = onfile.fDiscriminationByVLooseCombinedIsolationDBSumPtCorr; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByLooseCombinedIsolationDBSumPtCorr - dOffset] = onfile.fDiscriminationByLooseCombinedIsolationDBSumPtCorr; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByMediumCombinedIsolationDBSumPtCorr - dOffset] = onfile.fDiscriminationByMediumCombinedIsolationDBSumPtCorr; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByTightCombinedIsolationDBSumPtCorr - dOffset] = onfile.fDiscriminationByTightCombinedIsolationDBSumPtCorr; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByRawCombinedIsolationDBSumPtCorr - dOffset] = onfile.fDiscriminationByRawCombinedIsolationDBSumPtCorr; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByLooseMuonRejection2 - dOffset] = onfile.fLooseMuonRejection2; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByMediumMuonRejection2 - dOffset] = onfile.fMediumMuonRejection2; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByTightMuonRejection2 - dOffset] = onfile.fTightMuonRejection2; }" \
+
+
+#pragma read \
+    sourceClass="mithep::PFTau" \
+    version="[8]" \
+    source="Double32_t fPFTauDiscriminator[30];" \
+    targetClass="mithep::PFTau" \
+    target="fPFTauDiscriminator, fPFTauLegacyDiscriminator" \
+    code="{ enum OldDiscriminators { \
+        lDiscriminationByLooseElectronRejection, \
+        lDiscriminationByMediumElectronRejection, \
+        lDiscriminationByTightElectronRejection, \
+        lDiscriminationByMVA5VLooseElectronRejection, \
+        lDiscriminationByMVA5LooseElectronRejection, \
+        lDiscriminationByMVA5MediumElectronRejection, \
+        lDiscriminationByMVA5TightElectronRejection, \
+        lDiscriminationByLooseMuonRejection, \
+        lDiscriminationByMediumMuonRejection, \
+        lDiscriminationByTightMuonRejection, \
+        lDiscriminationByLooseMuonRejection2, \
+        lDiscriminationByMediumMuonRejection2, \
+        lDiscriminationByTightMuonRejection2, \
+        lDiscriminationByLooseMuonRejection3, \
+        lDiscriminationByTightMuonRejection3, \
+        lDiscriminationByDecayModeFinding, \
+        lDiscriminationByDecayModeFindingNewDMs, \
+        lDiscriminationByDecayModeFindingOldDMs, \
+        lDiscriminationByVLooseCombinedIsolationDBSumPtCorr, \
+        lDiscriminationByLooseCombinedIsolationDBSumPtCorr, \
+        lDiscriminationByMediumCombinedIsolationDBSumPtCorr, \
+        lDiscriminationByTightCombinedIsolationDBSumPtCorr, \
+        lDiscriminationByRawCombinedIsolationDBSumPtCorr, \
+        lDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits, \
+        lDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits, \
+        lDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits, \
+        lDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits, \
+        lMVA3IsolationChargedIsoPtSum, \
+        lMVA3IsolationNeutralIsoPtSum, \
+        lMVA3IsolationPUcorrPtSum \
+      }; \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByMVA5VLooseElectronRejection] = onfile.fPFTauDiscriminator[lDiscriminationByMVA5VLooseElectronRejection]; \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByMVA5LooseElectronRejection] = onfile.fPFTauDiscriminator[lDiscriminationByMVA5LooseElectronRejection]; \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByMVA5MediumElectronRejection] = onfile.fPFTauDiscriminator[lDiscriminationByMVA5MediumElectronRejection]; \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByMVA5TightElectronRejection] = onfile.fPFTauDiscriminator[lDiscriminationByMVA5TightElectronRejection]; \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByLooseMuonRejection3] = onfile.fPFTauDiscriminator[lDiscriminationByLooseMuonRejection3]; \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByTightMuonRejection3] = onfile.fPFTauDiscriminator[lDiscriminationByTightMuonRejection3]; \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByDecayModeFinding] = onfile.fPFTauDiscriminator[lDiscriminationByDecayModeFinding]; \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByDecayModeFindingNewDMs] = onfile.fPFTauDiscriminator[lDiscriminationByDecayModeFindingNewDMs]; \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits] = onfile.fPFTauDiscriminator[lDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits]; \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits] = onfile.fPFTauDiscriminator[lDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits]; \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits] = onfile.fPFTauDiscriminator[lDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits]; \
+      fPFTauDiscriminator[mithep::PFTau::kDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits] = onfile.fPFTauDiscriminator[lDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits]; \
+      unsigned const dOffset = mithep::PFTau::nDiscriminators; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByLooseElectronRejection - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByLooseElectronRejection]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByMediumElectronRejection - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByMediumElectronRejection]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByTightElectronRejection - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByTightElectronRejection]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByLooseMuonRejection - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByLooseMuonRejection]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByMediumMuonRejection - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByMediumMuonRejection]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByTightMuonRejection - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByTightMuonRejection]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByLooseMuonRejection2 - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByLooseMuonRejection2]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByMediumMuonRejection2 - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByMediumMuonRejection2]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByTightMuonRejection2 - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByTightMuonRejection2]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByDecayModeFindingOldDMs - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByDecayModeFindingOldDMs]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByVLooseCombinedIsolationDBSumPtCorr - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByVLooseCombinedIsolationDBSumPtCorr]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByLooseCombinedIsolationDBSumPtCorr - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByLooseCombinedIsolationDBSumPtCorr]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByMediumCombinedIsolationDBSumPtCorr - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByMediumCombinedIsolationDBSumPtCorr]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByTightCombinedIsolationDBSumPtCorr - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByTightCombinedIsolationDBSumPtCorr]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kDiscriminationByRawCombinedIsolationDBSumPtCorr - dOffset] = onfile.fPFTauDiscriminator[lDiscriminationByRawCombinedIsolationDBSumPtCorr]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kMVA3IsolationChargedIsoPtSum - dOffset] = onfile.fPFTauDiscriminator[lMVA3IsolationChargedIsoPtSum]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kMVA3IsolationNeutralIsoPtSum - dOffset] = onfile.fPFTauDiscriminator[lMVA3IsolationNeutralIsoPtSum]; \
+      fPFTauLegacyDiscriminator[mithep::PFTau::kMVA3IsolationPUcorrPtSum - dOffset] = onfile.fPFTauDiscriminator[lMVA3IsolationPUcorrPtSum]; }" \
 
 #pragma link C++ class mithep::PFTau+;
 #pragma link C++ class mithep::Collection<mithep::PFTau>+;

--- a/DataTree/interface/MCParticle.h
+++ b/DataTree/interface/MCParticle.h
@@ -24,14 +24,14 @@ namespace mithep
     public:
       enum EPartType {
         kUnknown=0, 
-        kUp=1, kDown=2, kStrange=3, kCharm=4, kBottom=5, kTop=6,
+        kDown=1, kUp, kStrange=3, kCharm=4, kBottom=5, kTop=6,
         kEl=11, kMu=13, kTau=15, 
         kElNu=12, kMuNu=14, kTauNu=16,
         kGlu=21, kGamma=22, kZ=23, kW=24, kH=25,
         kZp=32, kZpp=33, kWp=34, kH0=35, kA0=36, kHp=37,
-        kPi0=111, kEta=221, kKLong=130, kKShort=310, kK0=311,
-        kD0=413, kB0=511, kB0Bar=513, kJPsi=443, kUpsilon=553,
-        kProton=2122, kNeutron=2122, kDeltaPlusPlus = 2224,
+        kPi0=111, kPip=211, kEta=221, kKLong=130, kKShort=310, kK0=311,
+        kD0=421, kB0=511, kJPsi=443, kUpsilon=553,
+        kProton=2212, kNeutron=2112, kDeltaPlusPlus = 2224,
         kDeltaPlus = 2214, kDelta0 = 2114, kDeltaMinus=1114
       };
 
@@ -69,6 +69,7 @@ namespace mithep
       Int_t               PdgId()                  const { return fPdgId;  }
       Double_t            PdgMass()                const;
       Bool_t              StatusFlag(UInt_t i)     const { return fStatusFlags.TestBit(i); }
+      mithep::BitMask<2> const& StatusFlags()      const { return fStatusFlags; }
       void		  SetPtEtaPhiM(Double_t pt, Double_t eta, Double_t phi, Double_t m);
       void		  SetMom(Double_t px, Double_t py, Double_t pz, Double_t e);
       void		  SetMother(const MCParticle *p) { fMother = p;    }
@@ -95,7 +96,7 @@ namespace mithep
       Bool_t              fIsSimulated;  //=true if simulated particle
       mithep::BitMask<2>  fStatusFlags;  //pythia8 status flags
 
-    ClassDef(MCParticle,3) // Generated particle class
+    ClassDef(MCParticle,4) // Generated particle class
   };
 }
 

--- a/DataTree/interface/PFCandidate.h
+++ b/DataTree/interface/PFCandidate.h
@@ -21,7 +21,6 @@ namespace mithep
   class Muon;
   class Electron;
   class Photon;
-  class Conversion;
 
   class PFCandidate : public CompositeParticle
   {
@@ -66,7 +65,6 @@ namespace mithep
       void		  AddDaughter(const PFCandidate *p) { fDaughters.Add(p);                  }
       void                ClearFlag(EPFFlags f)             { fPFFlags.ClearBit(f);               }
       void                ClearFlags()                      { fPFFlags.Clear();                   }
-      const Conversion   *Conv()                   const;
       const PFCandidate  *Daughter(UInt_t i)       const;
       Double_t            EECal()                  const    { return fEECal;                      }
       Double_t            EHCal()                  const    { return fEHCal;                      }
@@ -85,7 +83,6 @@ namespace mithep
       Double_t            EtaECal()                const    { return fEtaECal;                    }
       Double_t            PhiECal()                const    { return fPhiECal;                    }
       Bool_t              Flag(EPFFlags f)         const    { return fPFFlags.TestBit(f);         }
-      Bool_t              HasConversion()          const;
       Bool_t              HasMother()              const    { return fMother.IsValid();           }
       Bool_t              HasMother(const PFCandidate *m) const;
       Bool_t              HasTrackerTrk()          const    { return fTrackerTrack.IsValid();     }
@@ -126,7 +123,6 @@ namespace mithep
       void                SetMuon(const Muon *);
       void                SetElectron(const Electron *);
       void                SetPhoton(const Photon *);
-      void                SetConversion(const Conversion *);
       void                SetSCluster(const SuperCluster *s) { fSCluster = s;                     }
       void                SetVertex(Double_t x, Double_t y, Double_t z);
       const ThreeVector   SourceVertex()           const    { return fSourceVertex.V();           }
@@ -166,12 +162,11 @@ namespace mithep
       Ref<Track>          fTrackerTrack;     //reference to (standard) track
       Ref<Track>          fGsfTrack;         //reference to gsf track (for electrons only)
       Ref<Muon>           fMuon;             //reference to corresponding reco muon
-      Ref<Conversion>     fConversion;       //reference to corresponding reco conversion
       Ref<SuperCluster>   fSCluster;         //reference to egamma supercluster
       Ref<Electron>       fElectron;         //reference to electron
       Ref<Photon>         fPhoton;           //reference to egamma photon
 
-    ClassDef(PFCandidate,3) // Particle-flow candidate class
+    ClassDef(PFCandidate,4) // Particle-flow candidate class
   };
 }
 

--- a/DataTree/interface/PFTau.h
+++ b/DataTree/interface/PFTau.h
@@ -21,29 +21,14 @@ namespace mithep {
   class PFTau : public Tau {
   public:
     enum Discriminator {
-      kDiscriminationByLooseElectronRejection, // againstElectronLoose
-      kDiscriminationByMediumElectronRejection, // againstElectronMedium
-      kDiscriminationByTightElectronRejection, // againstElectronTight
       kDiscriminationByMVA5VLooseElectronRejection, // againstElectronVLooseMVA5
       kDiscriminationByMVA5LooseElectronRejection, // againstElectronLooseMVA5
       kDiscriminationByMVA5MediumElectronRejection, // againstElectronMediumMVA5
       kDiscriminationByMVA5TightElectronRejection, // againstElectronTightMVA5
-      kDiscriminationByLooseMuonRejection, // againstMuonLoose
-      kDiscriminationByMediumMuonRejection, // againstMuonMedium
-      kDiscriminationByTightMuonRejection, // againstMuonTight
-      kDiscriminationByLooseMuonRejection2, // againstMuonLoose2
-      kDiscriminationByMediumMuonRejection2, // againstMuonMedium2
-      kDiscriminationByTightMuonRejection2, // againstMuonTight2
       kDiscriminationByLooseMuonRejection3, // againstMuonLoose3
       kDiscriminationByTightMuonRejection3, // againstMuonTight3
       kDiscriminationByDecayModeFinding, // decayModeFinding
       kDiscriminationByDecayModeFindingNewDMs, // decayModeFindingNewDMs
-      kDiscriminationByDecayModeFindingOldDMs, // decayModeFindingOldDMs
-      kDiscriminationByVLooseCombinedIsolationDBSumPtCorr, // byVLooseCombinedIsolationDeltaBetaCorr
-      kDiscriminationByLooseCombinedIsolationDBSumPtCorr, // byLooseCombinedIsolationDeltaBetaCorr
-      kDiscriminationByMediumCombinedIsolationDBSumPtCorr, // byMediumCombinedIsolationDeltaBetaCorr
-      kDiscriminationByTightCombinedIsolationDBSumPtCorr, // byTightCombinedIsolationDeltaBetaCorr
-      kDiscriminationByRawCombinedIsolationDBSumPtCorr, // byCombinedIsolationDeltaBetaCorrRaw
       kDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits, // byLooseCombinedIsolationDeltaBetaCorr3Hits
       kDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits, // byMediumCombinedIsolationDeltaBetaCorr3Hits
       kDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits, // byTightCombinedIsolationDeltaBetaCorr3Hits
@@ -81,6 +66,21 @@ namespace mithep {
       kMVA3IsolationChargedIsoPtSum, // chargedIsoPtSum (<= 7_4_6 ?)
       kMVA3IsolationNeutralIsoPtSum, // chargedIsoPtSum
       kMVA3IsolationPUcorrPtSum, // puCorrPtSum
+      kDiscriminationByLooseElectronRejection, // againstElectronLoose
+      kDiscriminationByMediumElectronRejection, // againstElectronMedium
+      kDiscriminationByTightElectronRejection, // againstElectronTight
+      kDiscriminationByLooseMuonRejection, // againstMuonLoose
+      kDiscriminationByMediumMuonRejection, // againstMuonMedium
+      kDiscriminationByTightMuonRejection, // againstMuonTight
+      kDiscriminationByLooseMuonRejection2, // againstMuonLoose2
+      kDiscriminationByMediumMuonRejection2, // againstMuonMedium2
+      kDiscriminationByTightMuonRejection2, // againstMuonTight2
+      kDiscriminationByDecayModeFindingOldDMs, // decayModeFindingOldDMs
+      kDiscriminationByVLooseCombinedIsolationDBSumPtCorr, // byVLooseCombinedIsolationDeltaBetaCorr
+      kDiscriminationByLooseCombinedIsolationDBSumPtCorr, // byLooseCombinedIsolationDeltaBetaCorr
+      kDiscriminationByMediumCombinedIsolationDBSumPtCorr, // byMediumCombinedIsolationDeltaBetaCorr
+      kDiscriminationByTightCombinedIsolationDBSumPtCorr, // byTightCombinedIsolationDeltaBetaCorr
+      kDiscriminationByRawCombinedIsolationDBSumPtCorr, // byCombinedIsolationDeltaBetaCorrRaw
       nAllDiscriminators,
       nLegacyDiscriminators = nAllDiscriminators - nDiscriminators
     };

--- a/DataTree/interface/PFTau.h
+++ b/DataTree/interface/PFTau.h
@@ -48,9 +48,14 @@ namespace mithep {
       kDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits, // byMediumCombinedIsolationDeltaBetaCorr3Hits
       kDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits, // byTightCombinedIsolationDeltaBetaCorr3Hits
       kDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits, // byCombinedIsolationDeltaBetaCorrRaw3Hits
-      kMVA3IsolationChargedIsoPtSum, // chargedIsoPtSum
-      kMVA3IsolationNeutralIsoPtSum, // chargedIsoPtSum
-      kMVA3IsolationPUcorrPtSum, // puCorrPtSum
+      kDiscriminationByLoosePileupWeightedIsolation3Hits, // byLoosePileupWeightedIsolation3Hits
+      kDiscriminationByMediumPileupWeightedIsolation3Hits, // byMediumPileupWeightedIsolation3Hits
+      kDiscriminationByTightPileupWeightedIsolation3Hits, // byTightPileupWeightedIsolation3Hits
+      kDiscriminationByRawPileupWeightedIsolation3Hits, // byPileupWeightedIsolationRaw3Hits
+      kDiscriminationByPhotonPtSumOutsideSignalCone, // byPhotonPtSumOutsideSignalCone
+      kChargedIsoPtSum, // chargedIsoPtSum
+      kNeutralIsoPtSum, // neutralIsoPtSum
+      kPUcorrPtSum, // puCorrPtSum
       nDiscriminators
     };
 
@@ -73,8 +78,33 @@ namespace mithep {
       kMVA3MediumElectronRejection,
       kMVA3TightElectronRejection,
       kMVA3VTightElectronRejection,
+      kMVA3IsolationChargedIsoPtSum, // chargedIsoPtSum (<= 7_4_6 ?)
+      kMVA3IsolationNeutralIsoPtSum, // chargedIsoPtSum
+      kMVA3IsolationPUcorrPtSum, // puCorrPtSum
       nAllDiscriminators,
       nLegacyDiscriminators = nAllDiscriminators - nDiscriminators
+    };
+
+    // Taken from DataFormats/TauReco/interface/PFTaus.h
+    enum HadronicDecayMode {
+      kNull = -1,
+      kOneProng0PiZero,
+      kOneProng1PiZero,
+      kOneProng2PiZero,
+      kOneProng3PiZero,
+      kOneProngNPiZero,
+      kTwoProng0PiZero,
+      kTwoProng1PiZero,
+      kTwoProng2PiZero,
+      kTwoProng3PiZero,
+      kTwoProngNPiZero,
+      kThreeProng0PiZero,
+      kThreeProng1PiZero,
+      kThreeProng2PiZero,
+      kThreeProng3PiZero,
+      kThreeProngNPiZero,
+      kRareDecayMode,
+      nHadronicDecayModes = kRareDecayMode + 2 // accounting the fact that the enum starts at -1
     };
 
     PFTau();
@@ -92,9 +122,12 @@ namespace mithep {
     Double_t ElectronPreIDOutput() const { return fElectronPreIDOutput; }
     Double_t CaloCompatibility() const { return fCaloCompatibility; }
     Double_t SegmentCompatibility() const { return fSegmentCompatibility; }
+    Double_t SignalConeSize() const { return fSignalConeSize; }
+    Double_t BendCorrMass() const { return fBendCorrMass; }
     Bool_t ElectronPreIDDecision() const { return fElectronPreIDDecision; }
     Bool_t MuonDecision() const { return fMuonDecision; }
     Double_t PFTauDiscriminator(UInt_t) const;
+    HadronicDecayMode DecayMode() const { return fHadronicDecayMode; }
     PFCandidate const* LeadPFCand() const { return fLeadPFCand.Obj(); }
     PFCandidate const* LeadChargedHadronPFCand() const { return fLeadChargedHadPFCand.Obj(); }
     PFCandidate const* LeadNeutralHadronPFCand() const { return fLeadNeutralPFCand.Obj(); }
@@ -129,6 +162,8 @@ namespace mithep {
     void SetElectronPreIDOutput(Double_t x) { fElectronPreIDOutput = x; }
     void SetCaloCompatibility(Double_t x) { fCaloCompatibility = x; }
     void SetSegmentCompatibility(Double_t x) { fSegmentCompatibility = x; }
+    void SetSignalConeSize(Double_t x) { fSignalConeSize = x; }
+    void SetBendCorrMass(Double_t x) { fBendCorrMass = x; }
     void SetElectronPreIDDecision(Bool_t b) { fElectronPreIDDecision = b; }
     void SetMuonDecision(Bool_t b) { fMuonDecision = b; }
     void SetPFTauDiscriminator(Double_t, UInt_t);
@@ -141,7 +176,8 @@ namespace mithep {
     void AddSignalPFChargedHadrCand(PFCandidate const* p) { fSignalPFChargedHadrCands.Add(p); }
     void AddSignalPFNeutrHadrCand(PFCandidate const* p) { fSignalPFNeutrHadrCands.Add(p); }
     void AddSignalPFGammaCand(PFCandidate const* p) { fSignalPFGammaCands.Add(p); }
-    void AddIsoPFCand(PFCandidate const* p) { fIsoPFCands.Add(p); }
+    void AddIsoPFCand(PFCandidate const* p) { fIsoPFCands.Add(p); }\
+    void SetDecayMode(HadronicDecayMode mode) { fHadronicDecayMode = mode; }
 
     // Some structural tools
     void Mark(UInt_t i=1) const override;
@@ -242,10 +278,14 @@ namespace mithep {
     Double32_t fElectronPreIDOutput; //[0,0,14]pfel pre id bdt output to be an el
     Double32_t fCaloCompatibility; //[0,0,14]calo comp. for this tau to be a muon
     Double32_t fSegmentCompatibility; //[0,0,14]segment comp. for this tau to be a muon
+    Double32_t fSignalConeSize; // dynamic strip reconstruction has variable cone size
+    Double32_t fBendCorrMass; // mass correction due to the use of dynamic strip
     Bool_t fElectronPreIDDecision; //pf electron pre id decision
     Bool_t fMuonDecision; //pf muon id decision
     Double32_t fPFTauDiscriminator[nDiscriminators];
     Double_t fPFTauLegacyDiscriminator[nLegacyDiscriminators]; //! only for reading old data
+
+    HadronicDecayMode fHadronicDecayMode; // decay mode
 
     Ref<PFCandidate> fLeadPFCand; //leading sig pf cand (charged or neutral)
     Ref<PFCandidate> fLeadChargedHadPFCand; //leading charged hadron signal pf cand
@@ -258,7 +298,7 @@ namespace mithep {
     RefArray<PFCandidate> fSignalPFGammaCands; //signal pf gamma candidates
     RefArray<PFCandidate> fIsoPFCands; //selected pf candidates in isolation annulus
 
-    ClassDef(PFTau, 8) // PFTau class
+    ClassDef(PFTau, 9) // PFTau class
   };
 }
 

--- a/DataTree/interface/PFTau.h
+++ b/DataTree/interface/PFTau.h
@@ -1,7 +1,7 @@
 //--------------------------------------------------------------------------------------------------
 // PFTau
 //
-// This class holds information about reconst* ucted tau based on PFCandidates.
+// This class holds information about reconstructed tau based on PFCandidates.
 //
 // Authors: J.Bendavid, C.Paus, Y.Iiyama
 //--------------------------------------------------------------------------------------------------

--- a/DataTree/interface/RunInfo.h
+++ b/DataTree/interface/RunInfo.h
@@ -18,20 +18,22 @@ namespace mithep
   class RunInfo : public DataBase
   {
     public:
-      RunInfo() : fRunNum(0), fHltEntry(0) {}
-      RunInfo(UInt_t run) : fRunNum(run), fHltEntry(0) {}
+      RunInfo() : fRunNum(0), fHltEntry(0), fEvtSelBitsEntry(-1) {}
+      RunInfo(UInt_t run) : fRunNum(run), fHltEntry(0), fEvtSelBitsEntry(-1) {}
 
       Int_t               HltEntry()     const { return fHltEntry; }
       EObjType            ObjType()      const { return kRunInfo;  }      
       UInt_t              RunNum()       const { return fRunNum;   }
       void                SetHltEntry(Int_t i) { fHltEntry=i;      }
       void                SetRunNum(UInt_t i)  { fRunNum=i;        }
+      void                SetEvtSelBitsEntry(Int_t i) { fEvtSelBitsEntry = i; }
 
     protected:
       UInt_t              fRunNum;          //run number
       Int_t               fHltEntry;        //entry for HLT block
+      Int_t               fEvtSelBitsEntry; //entry for EvtSelData bit names
 
-    ClassDef(RunInfo, 2) // Run info class
+    ClassDef(RunInfo, 3) // Run info class
   };
 }
 #endif

--- a/DataTree/src/PFCandidate.cc
+++ b/DataTree/src/PFCandidate.cc
@@ -2,23 +2,10 @@
 #include "MitAna/DataTree/interface/Muon.h"
 #include "MitAna/DataTree/interface/Electron.h"
 #include "MitAna/DataTree/interface/Photon.h"
-#include "MitAna/DataTree/interface/Conversion.h"
 
 ClassImp(mithep::PFCandidate)
 
 // Object reference accessors ins src file to avoid circular dependence of header files
-
-mithep::Conversion const*
-mithep::PFCandidate::Conv() const
-{
-  return fConversion.Obj();
-}
-
-Bool_t
-mithep::PFCandidate::HasConversion() const
-{
-  return fConversion.IsValid();
-}
 
 mithep::Muon const*
 mithep::PFCandidate::Mu() const
@@ -36,12 +23,6 @@ mithep::Photon const*
 mithep::PFCandidate::Pho() const
 {
   return fPhoton.Obj();
-}
-
-void
-mithep::PFCandidate::SetConversion(Conversion const* c)
-{
-  fConversion = c;
 }
 
 void
@@ -75,8 +56,6 @@ mithep::PFCandidate::Mark(UInt_t ib) const
     fGsfTrack.Obj()->Mark(ib);
   if (fMuon.IsValid())
     fMuon.Obj()->Mark(ib);
-  if (fConversion.IsValid())
-    fConversion.Obj()->Mark(ib);
   if (fSCluster.IsValid())
     fSCluster.Obj()->Mark(ib);
 }

--- a/DataTree/src/PFTau.cc
+++ b/DataTree/src/PFTau.cc
@@ -42,12 +42,6 @@ char const*
 mithep::PFTau::PFTauDiscriminatorName(UInt_t idx)
 {
   switch(idx) {
-  case kDiscriminationByLooseElectronRejection:
-    return "DiscriminationByLooseElectronRejection";
-  case kDiscriminationByMediumElectronRejection:
-    return "DiscriminationByMediumElectronRejection";
-  case kDiscriminationByTightElectronRejection:
-    return "DiscriminationByTightElectronRejection";
   case kDiscriminationByMVA5VLooseElectronRejection:
     return "DiscriminationByMVA5VLooseElectronRejection";
   case kDiscriminationByMVA5LooseElectronRejection:
@@ -56,18 +50,6 @@ mithep::PFTau::PFTauDiscriminatorName(UInt_t idx)
     return "DiscriminationByMVA5MediumElectronRejection";
   case kDiscriminationByMVA5TightElectronRejection:
     return "DiscriminationByMVA5TightElectronRejection";
-  case kDiscriminationByLooseMuonRejection:
-    return "DiscriminationByLooseMuonRejection";
-  case kDiscriminationByMediumMuonRejection:
-    return "DiscriminationByMediumMuonRejection";
-  case kDiscriminationByTightMuonRejection:
-    return "DiscriminationByTightMuonRejection";
-  case kDiscriminationByLooseMuonRejection2:
-    return "DiscriminationByLooseMuonRejection2";
-  case kDiscriminationByMediumMuonRejection2:
-    return "DiscriminationByMediumMuonRejection2";
-  case kDiscriminationByTightMuonRejection2:
-    return "DiscriminationByTightMuonRejection2";
   case kDiscriminationByLooseMuonRejection3:
     return "DiscriminationByLooseMuonRejection3";
   case kDiscriminationByTightMuonRejection3:
@@ -76,18 +58,6 @@ mithep::PFTau::PFTauDiscriminatorName(UInt_t idx)
     return "DiscriminationByDecayModeFinding";
   case kDiscriminationByDecayModeFindingNewDMs:
     return "DiscriminationByDecayModeFindingNewDMs";
-  case kDiscriminationByDecayModeFindingOldDMs:
-    return "DiscriminationByDecayModeFindingOldDMs";
-  case kDiscriminationByVLooseCombinedIsolationDBSumPtCorr:
-    return "DiscriminationByVLooseCombinedIsolationDBSumPtCorr";
-  case kDiscriminationByLooseCombinedIsolationDBSumPtCorr:
-    return "DiscriminationByLooseCombinedIsolationDBSumPtCorr";
-  case kDiscriminationByMediumCombinedIsolationDBSumPtCorr:
-    return "DiscriminationByMediumCombinedIsolationDBSumPtCorr";
-  case kDiscriminationByTightCombinedIsolationDBSumPtCorr:
-    return "DiscriminationByTightCombinedIsolationDBSumPtCorr";
-  case kDiscriminationByRawCombinedIsolationDBSumPtCorr:
-    return "DiscriminationByRawCombinedIsolationDBSumPtCorr";
   case kDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits:
     return "DiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits";
   case kDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits:
@@ -96,12 +66,22 @@ mithep::PFTau::PFTauDiscriminatorName(UInt_t idx)
     return "DiscriminationByTightCombinedIsolationDBSumPtCorr3Hits";
   case kDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits:
     return "DiscriminationByRawCombinedIsolationDBSumPtCorr3Hits";
-  case kMVA3IsolationChargedIsoPtSum:
-    return "MVA3IsolationChargedIsoPtSum";
-  case kMVA3IsolationNeutralIsoPtSum:
-    return "MVA3IsolationNeutralIsoPtSum";
-  case kMVA3IsolationPUcorrPtSum:
-    return "MVA3IsolationPUcorrPtSum";
+  case kDiscriminationByLoosePileupWeightedIsolation3Hits:
+    return "DiscriminationByLoosePileupWeightedIsolation3Hits";
+  case kDiscriminationByMediumPileupWeightedIsolation3Hits:
+    return "DiscriminationByMediumPileupWeightedIsolation3Hits";
+  case kDiscriminationByTightPileupWeightedIsolation3Hits:
+    return "DiscriminationByTightPileupWeightedIsolation3Hits";
+  case kDiscriminationByRawPileupWeightedIsolation3Hits:
+    return "DiscriminationByRawPileupWeightedIsolation3Hits";
+  case kDiscriminationByPhotonPtSumOutsideSignalCone:
+    return "DiscriminationByPhotonPtSumOutsideSignalCone";
+  case kChargedIsoPtSum:
+    return "ChargedIsoPtSum";
+  case kNeutralIsoPtSum:
+    return "NeutralIsoPtSum";
+  case kPUcorrPtSum:
+    return "PUcorrPtSum";
   default:
     return "";
   }

--- a/bin/requestFile.sh
+++ b/bin/requestFile.sh
@@ -119,8 +119,15 @@ then
     exit $?
   elif [ "$localopt" = "copy" ]
   then
-    # using cp with FUSE is faster than hdfs dfs -get
-    ( cp $cache $file.cp && mv $file.cp $file ) &
+    hdfspath=$(echo $cache | sed 's#/mnt/hadoop##')
+    if [[ $(hostname) =~ .*cmsaf.mit.edu ]]
+    then
+      cmd="hadoop dfs -get"
+    else
+      cmd="hdfs dfs -fs hdfs://t3serv002.mit.edu:9000 -get"
+    fi
+    ( itry=0; while [ $itry -lt 10 ] && [ ! -e $file ]; do $cmd $hdfspath $file; itry=$(($itry+1)); done ) &
+#    ( cp $cache ${file}.copy && mv ${file}.copy $file ) &
     exit 0
   fi
 fi

--- a/bin/runOnDatasets.py
+++ b/bin/runOnDatasets.py
@@ -389,6 +389,11 @@ class CondorConfig(object):
 ## MAIN EXECUTABLE FUNCTIONS (PROBABLY BETTER IN A CLASS IN FUTURE) ##
 ######################################################################
 
+def copyX509Proxy(env):
+    if os.path.exists('/tmp/' + env.x509up):
+        shutil.copy('/tmp/' + env.x509up, env.workspace + '/' + env.x509up)
+
+
 def setupWorkspace(env):
     """
     Set up the directory structure and create tarballs.
@@ -437,8 +442,7 @@ def setupWorkspace(env):
         shutil.copyfile(env.postExecPath, env.workspace + '/postExec.sh')
 
     # copy the latest user proxy
-    if os.path.exists('/tmp/' + env.x509up):
-        shutil.copy('/tmp/' + env.x509up, env.workspace + '/' + env.x509up)
+    copyX509Proxy(env)
 
     # copy the execution script
     if not env.update:
@@ -1151,6 +1155,8 @@ if __name__ == '__main__':
         ready = setupWorkspace(env)
         if not ready:
             sys.exit(1)
+
+    copyX509Proxy(env)
   
     # datasets: list of tuples (book, dataset, json)
     updateDatasetList = False


### PR DESCRIPTION
PFTau: Updated the list of discriminators. Reduced the number of active discriminators.
MCParticle: PDG ID enum was wrong.
PFCandidate: Removed conversion reference. GED e/gamma objects are made from multiple PF candidates, so it does not make sense for the individual PF candidates to have a reference to a conversion object.
RunInfo: EvtSelData (MET filters) is now filled in a similar manner to HLT, i.e. the list of active filters in each file is stored in a separate tree. RunInfo holds the entry number in this tree.