### PR TITLE
SetBit(kCanRebin) -> SetCanExtend(kXaxis)

### DIFF
--- a/PhysicsMod/src/PlotKineMod.cc
+++ b/PhysicsMod/src/PlotKineMod.cc
@@ -82,5 +82,5 @@ mithep::PlotKineMod::SlaveBegin()
 
   AddTH1(fMultHist, "hMultiplicity", ";Number of objects in " + fColName + ";", 10, 0., 10.);
 
-  //fMultHist->SetBit(TH1::kCanRebin); // CP: looks like bit disappeared in the new root version
+  fMultHist->SetCanExtend(TH1::kXaxis);
 }


### PR DESCRIPTION
This is the new way to tell ROOT that the TH1 can be rebinned automatically.