### PR TITLE
Format slimming

### DIFF
--- a/DataTree/interface/Electron.h
+++ b/DataTree/interface/Electron.h
@@ -80,10 +80,10 @@ namespace mithep
     Double_t             ConvPartnerRadius()           const { return fConvPartnerRadius; }
     Int_t                ConvFlag()                    const { return fConvFlag; }
     Int_t                Classification()              const { return fClassification; }
-    Double_t             CovEtaEta()                   const { return fCovEtaEta; }
-    Double_t             CoviEtaiEta(Bool_t force = kFALSE) const
-    { return force || fCoviEtaiEta5x5 < 0. ? fCoviEtaiEta : fCoviEtaiEta5x5; }
-    Double_t             CoviEtaiEta5x5()              const { return fCoviEtaiEta5x5; }
+    Double_t             CoviEtaiEta()                 const;
+    Double_t             CoviEtaiEta5x5()              const;
+    Double_t             CoviPhiiPhi()                 const { return SCluster()->SigmaIPhiIPhi(); }
+    Double_t             CoviEtaiPhi()                 const { return SCluster()->SigmaIEtaIPhi(); }
     Double_t             DeltaEtaSuperClusterTrackAtVtx() const { return fDeltaEtaSuperClTrkAtVtx; }
     Double_t             DeltaEtaSeedClusterTrackAtCalo() const { return fDeltaEtaSeedClTrkAtCalo; }
     Double_t             DeltaPhiSuperClusterTrackAtVtx() const { return fDeltaPhiSuperClTrkAtVtx; }
@@ -202,7 +202,6 @@ namespace mithep
     void                 SetConvPartnerRadius(Double_t x)              { fConvPartnerRadius = x; }
     void                 SetConvFlag(Int_t n)                          { fConvFlag = n; }
     void                 SetClassification(Int_t x)                    { fClassification = x; }
-    void                 SetCovEtaEta(Double_t x)                      { fCovEtaEta = x; }
     void                 SetCoviEtaiEta(Double_t x)                    { fCoviEtaiEta = x; }
     void                 SetCoviEtaiEta5x5(Double_t x)                 { fCoviEtaiEta5x5 = x; }
     void                 SetDeltaEtaSuperClusterTrackAtVtx(Double_t x)  
@@ -311,8 +310,7 @@ namespace mithep
     Double32_t        fE15;                          //[0,0,14]1x5 crystal energy
     Double32_t        fE25Max;                       //[0,0,14]2x5 crystal energy (max of two possible sums)
     Double32_t        fE55;                          //[0,0,14]5x5 crystal energy
-    Double32_t        fCovEtaEta;                    //[0,0,14]variance eta-eta
-    Double32_t        fCoviEtaiEta;                  //[0,0,14]covariance eta-eta (in crystals)
+    Double32_t        fCoviEtaiEta = -1.;            //[0,0,14]covariance eta-eta (in crystals)
     Double32_t        fCoviEtaiEta5x5 = -1.;         //[0,0,14]covariance eta-eta (in crystals, full5x5)
     Double32_t        fHcalDepth1TowerSumEtDr04;     //[0,0,14]hcal depth1 tower based isolation dR 0.4
     Double32_t        fHcalDepth2TowerSumEtDr04;     //[0,0,14]hcal depth2 tower based isolation dR 0.4
@@ -402,15 +400,17 @@ namespace mithep
     // The following members are deprecated
     //    Double32_t        fCaloIsolation;                //[0,0,14](non-jura) ecal isolation based on rechits dR 0.3
     //    Double32_t        fHcalJurassicIsolation;        //[0,0,14]hcal jura iso dR 0.4
+    //    Double32_t        fCovEtaEta;                    //[0,0,14]variance eta-eta
     // Accessors
     //    Double_t             CaloIsolation()               const { return fCaloIsolation; }
-    //    Double_t             HcalIsolation()                  const { return fHcalJurassicIsolation; }
+    //    Double_t             HcalIsolation()               const { return fHcalJurassicIsolation; }
+    //    Double_t             CovEtaEta()                   const { return fCovEtaEta; } 
     // fPFSuperClusterRef: member object name is kept the same as <7XY so that old files can be read
     // Should in principle be possible to use schema evolution to convert it to something like fECALOnlySuperClusterRef
     // The problem is that process ID seems to be not set at the point where conversion rules are applied
     // which is strange since process ID is set in ProcIDRef::Streamer..
 
-    ClassDef(Electron, 19)                             // Electron class
+    ClassDef(Electron, 20)                             // Electron class
   };
 }
 
@@ -446,6 +446,28 @@ inline const mithep::Track *mithep::Electron::BestTrk() const
     return TrackerTrk();
 
   return 0;
+}
+
+inline
+Double_t
+mithep::Electron::CoviEtaiEta() const
+{
+  if (fCoviEtaiEta5x5 >= 0.)
+    return fCoviEtaiEta5x5;
+  else if (fCoviEtaiEta >= 0.)
+    return fCoviEtaiEta;
+  else
+    return SCluster()->SigmaIEtaIEta();
+}
+
+inline
+Double_t
+mithep::Electron::CoviEtaiEta5x5() const
+{
+  if (fCoviEtaiEta5x5 >= 0.)
+    return fCoviEtaiEta5x5;
+  else
+    return SCluster()->SigmaIEtaIEta();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/DataTree/interface/FatJet.h
+++ b/DataTree/interface/FatJet.h
@@ -1,4 +1,4 @@
-//--------------------------------------------------------------------------------------------------
+ //--------------------------------------------------------------------------------------------------
 // FatJet
 //
 // This class holds information about reconstructed jets and their substructure
@@ -159,7 +159,7 @@ namespace mithep {
     std::vector<LeptonData> fMuonData{};
     std::vector<LeptonData> fElectronData{};
 
-    ClassDef(FatJet, 2) // FatJet class
+    ClassDef(FatJet, 3) // FatJet class
   };
 
 }

--- a/DataTree/interface/PFCandidate.h
+++ b/DataTree/interface/PFCandidate.h
@@ -3,7 +3,7 @@
 //
 // Particle-flow candidate class, for now mostly mirroring the PFCandidate from CMSSW.
 //
-// Authors: J.Bendavid
+// Authors: J.Bendavid, Y.Iiyama
 //--------------------------------------------------------------------------------------------------
 
 #ifndef MITANA_DATATREE_PFCandidate_H
@@ -57,10 +57,7 @@ namespace mithep
 	ePFNoPileup
       };
 
-      PFCandidate() : fCharge(0), fEECal(0), fEHCal(0), fEECalRaw(0), fEHCalRaw(0),
-                      fEPS1(0), fEPS2(0), fPError(0),fMvaEPi(0), fMvaEMu(0),
-                      fMvaPiMu(0), fMvaGamma(0), fMvaNeutralH(0), fMvaGammaNeutralH(0),
-                      fEtaECal(0), fPhiECal(0), fPFType(eX) {}
+      PFCandidate() : fPFType(eX) {}
 
       void		  AddDaughter(const PFCandidate *p) { fDaughters.Add(p);                  }
       void                ClearFlag(EPFFlags f)             { fPFFlags.ClearBit(f);               }
@@ -68,18 +65,9 @@ namespace mithep
       const PFCandidate  *Daughter(UInt_t i)       const;
       Double_t            EECal()                  const    { return fEECal;                      }
       Double_t            EHCal()                  const    { return fEHCal;                      }
-      Double_t            EECalRaw()               const    { return fEECalRaw;                   }
-      Double_t            EHCalRaw()               const    { return fEHCalRaw;                   }
-      Double_t            EPS1()                   const    { return fEPS1;                       }
-      Double_t            EPS2()                   const    { return fEPS2;                       }
       Double_t            PError()                 const    { return fPError;                     }
       PFCandidate*        MakeCopy()               const    { return new PFCandidate(*this);      }
-      Double_t            MvaEPi()                 const    { return fMvaEPi;                     }
-      Double_t            MvaEMu()                 const    { return fMvaEMu;                     }
-      Double_t            MvaPiMu()                const    { return fMvaPiMu;                    }
       Double_t            MvaGamma()               const    { return fMvaGamma;                   }
-      Double_t            MvaNeutralH()            const    { return fMvaNeutralH;                }
-      Double_t            MvaGammaNeutralH()       const    { return fMvaGammaNeutralH;           }
       Double_t            EtaECal()                const    { return fEtaECal;                    }
       Double_t            PhiECal()                const    { return fPhiECal;                    }
       Bool_t              Flag(EPFFlags f)         const    { return fPFFlags.TestBit(f);         }
@@ -100,17 +88,8 @@ namespace mithep
       void                SetCharge(Double_t c)             { fCharge = c; ClearCharge();         }
       void                SetEECal(Double_t e)              { fEECal = e;                         }
       void                SetEHCal(Double_t e)              { fEHCal = e;                         }
-      void                SetEECalRaw(Double_t e)           { fEECalRaw = e;                      }
-      void                SetEHCalRaw(Double_t e)           { fEHCalRaw = e;                      }
-      void                SetEPS1(Double_t e)               { fEPS1 = e;                          }
-      void                SetEPS2(Double_t e)               { fEPS2 = e;                          }
       void                SetPError(Double_t err)           { fPError = err;                      }
-      void                SetMvaEPi(Double_t d)             { fMvaEPi = d;                        }
-      void                SetMvaEMu(Double_t d)             { fMvaEMu = d;                        }
-      void                SetMvaPiMu(Double_t d)            { fMvaPiMu = d;                       }
       void                SetMvaGamma(Double_t d)           { fMvaGamma = d;                      }
-      void                SetMvaNeutralH(Double_t d)        { fMvaNeutralH = d;                   }
-      void                SetMvaGammaNeutralH(Double_t d)   { fMvaGammaNeutralH = d;              }
       void                SetEtaECal(Double_t eta)          { fEtaECal = eta;                     }
       void                SetPhiECal(Double_t phi)          { fPhiECal = phi;                     }
       void                SetPFType(EPFType t)              { fPFType = t;                        }
@@ -143,17 +122,8 @@ namespace mithep
       Double32_t          fCharge;           //[-1,1,2]charge
       Double32_t          fEECal;            //[0,0,14]corrected Ecal energy
       Double32_t          fEHCal;            //[0,0,14]corrected Hcal energy
-      Double32_t          fEECalRaw;         //[0,0,14]uncorrected Ecal energy
-      Double32_t          fEHCalRaw;         //[0,0,14]uncorrected Hcal energy
-      Double32_t          fEPS1;             //[0,0,14]corrected PS1 energy
-      Double32_t          fEPS2;             //[0,0,14]corrected PS2 energy
       Double32_t          fPError;           //[0,0,14]uncertainty on P (three-mom magnitude)
-      Double32_t          fMvaEPi;           //[0,0,14]electron-pion discriminant
-      Double32_t          fMvaEMu;           //[0,0,14]electron-muon discriminant
-      Double32_t          fMvaPiMu;          //[0,0,14]pion-muon discriminant
       Double32_t          fMvaGamma;         //[0,0,14]photon id discriminant
-      Double32_t          fMvaNeutralH;      //[0,0,14]neutral hadron id discriminant
-      Double32_t          fMvaGammaNeutralH; //[0,0,14]photon-neutralhadron discriminant
       Double32_t          fEtaECal;          //[0,0,12]eta at ecal front face
       Double32_t          fPhiECal;          //[0,0,12]phi at ecal front face
       EPFType             fPFType;           //particle flow type
@@ -166,7 +136,7 @@ namespace mithep
       Ref<Electron>       fElectron;         //reference to electron
       Ref<Photon>         fPhoton;           //reference to egamma photon
 
-    ClassDef(PFCandidate,4) // Particle-flow candidate class
+    ClassDef(PFCandidate,5) // Particle-flow candidate class
   };
 }
 

--- a/DataTree/interface/Photon.h
+++ b/DataTree/interface/Photon.h
@@ -49,10 +49,10 @@ namespace mithep
     Double_t             E33()                        const { return fE33;                }
     Double_t             E55()                        const { return fE55;                }
     ThreeVectorC         CaloPos()                    const;
-    Double_t             CovEtaEta()                  const { return fCovEtaEta;          }
-    Double_t             CoviEtaiEta(Bool_t force = kFALSE) const
-    { return force || fCoviEtaiEta5x5 < 0. ? fCoviEtaiEta : fCoviEtaiEta5x5; }
-    Double_t             CoviEtaiEta5x5()             const { return fCoviEtaiEta5x5;     }
+    Double_t             CoviEtaiEta()                const;
+    Double_t             CoviEtaiEta5x5()             const;
+    Double_t             CoviPhiiPhi()                const { return SCluster()->SigmaIPhiIPhi(); }
+    Double_t             CoviEtaiPhi()                const { return SCluster()->SigmaIEtaIPhi(); }
     Bool_t               HasPixelSeed()               const { return fHasPixelSeed;       }
     Double_t             HcalDepth1TowerSumEtDr03()   const { return fHcalDepth1TowerSumEtDr03; }
     Double_t             HcalDepth1TowerSumEtDr04()   const { return fHcalDepth1TowerSumEtDr04; }
@@ -151,7 +151,6 @@ namespace mithep
     void                 SetE25(Double_t x)                      { fE25                     = x; }
     void                 SetE33(Double_t x)                      { fE33                     = x; }
     void                 SetE55(Double_t x)                      { fE55                     = x; }
-    void                 SetCovEtaEta(Double_t x)                { fCovEtaEta               = x; }
     void                 SetCoviEtaiEta(Double_t x)              { fCoviEtaiEta             = x; }
     void                 SetCoviEtaiEta5x5(Double_t x)           { fCoviEtaiEta5x5          = x; }
     void                 SetHasPixelSeed(Bool_t x)               { fHasPixelSeed            = x; }
@@ -234,9 +233,8 @@ namespace mithep
     Double32_t           fE25;                      //[0,0,14]2x5 crystal energy
     Double32_t           fE33;                      //[0,0,14]3x3 crystal energy
     Double32_t           fE55;                      //[0,0,14]5x5 crystal energy
-    Double32_t           fCovEtaEta;                //[0,0,14]variance eta-eta
-    Double32_t           fCoviEtaiEta;              //[0,0,14]covariance eta-eta (in crystals)
-    Double32_t           fCoviEtaiEta5x5 = -1.;     //[0,0,14]"full 5x5" covariance eta-eta (in crystals)
+    Double32_t           fCoviEtaiEta = -1.;        //! covariance eta-eta (in crystals)
+    Double32_t           fCoviEtaiEta5x5 = -1.;     //! "full 5x5" covariance eta-eta (in crystals)
     Double32_t           fEcalRecHitIso;            //[0,0,14]ecal rechit bsd isodR 0.4 *RENAME*
     Double32_t           fHcalTowerSumEtDr04;       //[0,0,14]hcal tower bsd isodR 0.4
     Double32_t           fHcalDepth1TowerSumEtDr04; //[0,0,14]hcal dp1 tw bsd isodR 0.4
@@ -313,11 +311,13 @@ namespace mithep
     //    RefArray<Conversion> fConversions;        //refs to associated conversion candidates
     //    Bool_t               fIsLooseEM;          //if loose em cuts are passed
     //    Double32_t           fHcalRecHitIso;      //[0,0,14]hcal rechit bsd isodR 0.4
+    //    Double32_t           fCovEtaEta;
     //    RefArray<PFCandidate> fPFPhotonsInMustache; //refs to photon-type PFCandidates inside of mustache region
     //    RefArray<PFCandidate> fPFPhotonsOutOfMustache; //refs to photon-type PFCandidates outside of mustache region
     // Accessors
     //    const Conversion    *ConvCand(UInt_t i)           const { return fConversions.At(i);  }
     //    Double_t             HcalRecHitIso()              const { return 0.;         }
+    //    Double_t             CovEtaEta()                  const { return fCovEtaEta; }
     //    Bool_t               IsLooseEM()                  const { return true;             }
     //    UInt_t               NConversions()               const { return fConversions.Entries(); }
     //    UInt_t               NPFPhotonsInMustache()       const { return fPFPhotonsInMustache.Entries(); }
@@ -334,7 +334,7 @@ namespace mithep
     // The problem is that process ID seems to be not set at the point where conversion rules are applied
     // which is strange since process ID is set in ProcIDRef::Streamer..
 
-    ClassDef(Photon, 23) // Photon class
+    ClassDef(Photon, 24) // Photon class
   };
 }
 
@@ -366,6 +366,28 @@ mithep::Photon::CaloPos() const
     return calopos;
   else
     return SCluster()->Point();
+}
+
+inline
+Double_t
+mithep::Photon::CoviEtaiEta() const
+{
+  if (fCoviEtaiEta5x5 >= 0.)
+    return fCoviEtaiEta5x5;
+  else if (fCoviEtaiEta >= 0.)
+    return fCoviEtaiEta;
+  else
+    return SCluster()->SigmaIEtaIEta();
+}
+
+inline
+Double_t
+mithep::Photon::CoviEtaiEta5x5() const
+{
+  if (fCoviEtaiEta5x5 >= 0.)
+    return fCoviEtaiEta5x5;
+  else
+    return SCluster()->SigmaIEtaIEta();
 }
 
 inline

--- a/DataTree/interface/SuperCluster.h
+++ b/DataTree/interface/SuperCluster.h
@@ -23,15 +23,7 @@ namespace mithep
   class SuperCluster : public DataObject
   {
   public:
-    SuperCluster() : fEnergy(0), fEtaWidth(0), fPreshowerEnergy(0),
-                     fPhiWidth(0), fRawEnergy(0),
-                     fEtaC(-99.), fEtaS(-99.), fEtaM(-99.),
-                     fPhiC(-99.), fPhiS(-99.), fPhiM(-99.),
-                     fXC(-99.), fXS(-99.), fXM(-99.), fXZ(-99.),
-                     fYC(-99.), fYS(-99.), fYM(-99.), fYZ(-99.),
-                     fPreshowerEnergyPlane1(0.), fPreshowerEnergyPlane2(0.),
-                     fPsEffWidthSigmaXX(-99.), fPsEffWidthSigmaYY(-99.),
-                     fRoundness(-99.), fAngle(-99.) {}
+    SuperCluster() {}
 
     void                   AddCluster(const BasicCluster *c)          { fClusters.Add(c);        }
     void                   AddPsClust(const PsCluster *c)             { fPsClusts.Add(c);        }
@@ -50,12 +42,6 @@ namespace mithep
     Double_t               EtaWidth()              const { return fEtaWidth;                     }
     Bool_t                 HasSeed()               const { return fSeedRef.IsValid();            }
     Bool_t                 HasTower(const CaloTower *t) const { return fCaloTowers.HasObject(t); }
-    Double_t               HcalDepth1Energy()      const { return fHcalDepth1Energy;             }
-    Double_t               HcalDepth2Energy()      const { return fHcalDepth2Energy;             }
-    Double_t               HadDepth1OverEm()       const { return fHcalDepth1Energy/fEnergy;     }
-    Double_t               HadDepth2OverEm()       const { return fHcalDepth2Energy/fEnergy;     }
-    Double_t               HadOverEm()             const { return (fHcalDepth1Energy+
-                                                                   fHcalDepth2Energy)/fEnergy;   }
     Bool_t                 IsSortable()            const { return kTRUE;                         }
     EObjType               ObjType()               const { return kSuperCluster;                 }
     UInt_t                 NTowers()               const { return fCaloTowers.Entries();         }
@@ -68,23 +54,9 @@ namespace mithep
     Double_t               PreshowerEnergyPlane2() const { return fPreshowerEnergyPlane2;        }
     Double_t               RawEnergy()             const { return fRawEnergy;                    }
     Double_t               Rho()                   const { return fPoint.Rho();                  }
-    Double_t               R9()                    const { return fSeedRef.Obj()->E3x3()/fRawEnergy; }
+    Double_t               R9()                    const { return Seed()->E3x3()/fRawEnergy;     }
     const BasicCluster    *Seed()                  const { return fSeedRef.Obj();                }
     const CaloTower       *Tower(UInt_t i)         const { return fCaloTowers.At(i);             }
-    Double_t               EtaC()                  const { return fEtaC;                         }
-    Double_t               EtaS()                  const { return fEtaS;                         }
-    Double_t               EtaM()                  const { return fEtaM;                         }
-    Double_t               PhiC()                  const { return fPhiC;                         }
-    Double_t               PhiS()                  const { return fPhiS;                         }
-    Double_t               PhiM()                  const { return fPhiM;                         }
-    Double_t               XC()                    const { return fXC;                           }
-    Double_t               XS()                    const { return fXS;                           }
-    Double_t               XM()                    const { return fXM;                           }
-    Double_t               XZ()                    const { return fXZ;                           }
-    Double_t               YC()                    const { return fYC;                           }
-    Double_t               YS()                    const { return fYS;                           }
-    Double_t               YM()                    const { return fYM;                           }
-    Double_t               YZ()                    const { return fYZ;                           }
     Double_t               Time()                  const { return fTime;                         }
     Double_t               SeedTime()              const { return fSeedTime;                     }
     Double_t               LeadTimeSpan()          const { return fLeadTimeSpan;                 }
@@ -93,6 +65,9 @@ namespace mithep
     Double_t               PsEffWidthSigmaYY()     const { return fPsEffWidthSigmaYY;            }
     Double_t               Roundness()             const { return fRoundness;                    }
     Double_t               Angle()                 const { return fAngle;                        }
+    Double_t               SigmaIEtaIEta()         const { return fSigmaIEtaIEta;                }
+    Double_t               SigmaIPhiIPhi()         const { return fSigmaIPhiIPhi;                }
+    Double_t               SigmaIEtaIPhi()         const { return fSigmaIEtaIPhi;                }
 
     void                   SetEnergy(Double_t energy)                 { fEnergy = energy;        }
     void                   SetEtaWidth(Double_t etaWidth)             { fEtaWidth = etaWidth;    }
@@ -101,24 +76,8 @@ namespace mithep
     void                   SetPreshowerEnergyPlane1(Double_t e)       { fPreshowerEnergyPlane1 = e; }
     void                   SetPreshowerEnergyPlane2(Double_t e)       { fPreshowerEnergyPlane2 = e; }
     void                   SetRawEnergy(Double_t rawEnergy)           { fRawEnergy = rawEnergy;  }
-    void                   SetHcalDepth1Energy(Double_t x)            { fHcalDepth1Energy = x;   }
-    void                   SetHcalDepth2Energy(Double_t x)            { fHcalDepth2Energy = x;   }
     void                   SetSeed(const BasicCluster *s)             { fSeedRef = s;            }
     void                   SetXYZ(Double_t x, Double_t y, Double_t z) { fPoint.SetXYZ(x,y,z);    }
-    void                   SetEtaC(Double_t x)                        { fEtaC = x;               }
-    void                   SetEtaS(Double_t x)                        { fEtaS = x;               }
-    void                   SetEtaM(Double_t x)                        { fEtaM = x;               }
-    void                   SetPhiC(Double_t x)                        { fPhiC = x;               }
-    void                   SetPhiS(Double_t x)                        { fPhiS = x;               }
-    void                   SetPhiM(Double_t x)                        { fPhiM = x;               }
-    void                   SetXC(Double_t x)                          { fXC = x;                 }
-    void                   SetXS(Double_t x)                          { fXS = x;                 }
-    void                   SetXM(Double_t x)                          { fXM = x;                 }
-    void                   SetXZ(Double_t x)                          { fXZ = x;                 }
-    void                   SetYC(Double_t x)                          { fYC = x;                 }
-    void                   SetYS(Double_t x)                          { fYS = x;                 }
-    void                   SetYM(Double_t x)                          { fYM = x;                 }
-    void                   SetYZ(Double_t x)                          { fYZ = x;                 }
     void                   SetTime(Double_t x)                        { fTime = x;               }
     void                   SetSeedTime(Double_t x)                    { fSeedTime = x;           }
     void                   SetLeadTimeSpan(Double_t x)                { fLeadTimeSpan = x;       }
@@ -127,49 +86,39 @@ namespace mithep
     void                   SetPsEffWidthSigmaYY(Double_t x)           { fPsEffWidthSigmaYY = x;  }
     void                   SetRoundness(Double_t x)                   { fRoundness = x;          }
     void                   SetAngle(Double_t x)                       { fAngle = x;              }
+    void                   SetSigmaIEtaIEta(Double_t x)               { fSigmaIEtaIEta = x;      }
+    void                   SetSigmaIPhiIPhi(Double_t x)               { fSigmaIPhiIPhi = x;      }
+    void                   SetSigmaIEtaIPhi(Double_t x)               { fSigmaIEtaIPhi = x;      }
 
     // Some structural tools
     void                   Mark(UInt_t i=1)  const;
 
   protected:
     Vect3C                  fPoint;                //centroid Position
-    Double32_t              fEnergy;               //[0,0,14]super cluster energy
-    Double32_t              fEtaWidth;             //[0,0,14]width in Phi
-    Double32_t              fPreshowerEnergy;      //[0,0,14]energy in the preshower
-    Double32_t              fPhiWidth;             //[0,0,14]width in Phi
-    Double32_t              fRawEnergy;            //[0,0,14]super cluster raw energy
-    Double32_t              fHcalDepth1Energy;     //[0,0,14] hcal depth1 over ECAL energy
-    Double32_t              fHcalDepth2Energy;     //[0,0,14] hcal depth2 over ECAL energy
+    Double32_t              fEnergy = 0.;          //[0,0,14]super cluster energy
+    Double32_t              fEtaWidth = 0.;        //[0,0,14]width in Phi
+    Double32_t              fPreshowerEnergy = 0.; //[0,0,14]energy in the preshower
+    Double32_t              fPhiWidth = 0.;        //[0,0,14]width in Phi
+    Double32_t              fRawEnergy = 0.;       //[0,0,14]super cluster raw energy
     RefArray<BasicCluster>  fClusters;             //assigned basic clusters
     Ref<BasicCluster>       fSeedRef;              //seed cluster
     RefArray<CaloTower>     fCaloTowers;           //calo towers (matched by detid)
-    Double32_t              fEtaC;                 //local coordinates
-    Double32_t              fEtaS;                 //local coordinates
-    Double32_t              fEtaM;                 //local coordinates
-    Double32_t              fPhiC;                 //local coordinates
-    Double32_t              fPhiS;                 //local coordinates
-    Double32_t              fPhiM;                 //local coordinates
-    Double32_t              fXC;                   //local coordinates
-    Double32_t              fXS;                   //local coordinates
-    Double32_t              fXM;                   //local coordinates
-    Double32_t              fXZ;                   //local coordinates
-    Double32_t              fYC;                   //local coordinates
-    Double32_t              fYS;                   //local coordinates
-    Double32_t              fYM;                   //local coordinates
-    Double32_t              fYZ;                   //local coordinates
     Double32_t              fTime;                 //ecal timing (weighted average)
     Double32_t              fSeedTime;             //ecal timing (seed crystal)
     Double32_t              fLeadTimeSpan;         //ecal supercluster max timespan (seed vs. any other xtal)
     Double32_t              fSubLeadTimeSpan;      //ecal supercluster next-to-max timespan (seed vs. any other xtal)
-    Double32_t              fPreshowerEnergyPlane1;//local coordinates
-    Double32_t              fPreshowerEnergyPlane2;//local coordinates
-    Double32_t              fPsEffWidthSigmaXX;    //preshower cluster width in x plane
-    Double32_t              fPsEffWidthSigmaYY;    //preshower cluster width in y plane
+    Double32_t              fPreshowerEnergyPlane1 = 0.;//local coordinates
+    Double32_t              fPreshowerEnergyPlane2 = 0.;//local coordinates
+    Double32_t              fPsEffWidthSigmaXX = -99.;//preshower cluster width in x plane
+    Double32_t              fPsEffWidthSigmaYY = -99.;//preshower cluster width in y plane
     RefArray<PsCluster>     fPsClusts;             //assigned preshower clusters
-    Double32_t              fRoundness;            //smaller_SCaxis/larger_SCaxis: barrel only
-    Double32_t              fAngle;                //angle between SC axis and beam axis: barrel only
+    Double32_t              fRoundness = -99.;     //smaller_SCaxis/larger_SCaxis: barrel only
+    Double32_t              fAngle = -99.;         //angle between SC axis and beam axis: barrel only
+    Double32_t              fSigmaIEtaIEta = 0.;   //eta-diagonal of the logE-weighted covariance
+    Double32_t              fSigmaIPhiIPhi = 0.;   //phi-diagonal of the logE-weighted covariance
+    Double32_t              fSigmaIEtaIPhi = 0.;   //off-diagonal of the logE-weighted covariance
 
-    ClassDef(SuperCluster, 8) // Super cluster class
+    ClassDef(SuperCluster, 9) // Super cluster class
   };
 }
 

--- a/DataTree/interface/XlFatJet.h
+++ b/DataTree/interface/XlFatJet.h
@@ -102,7 +102,7 @@ namespace mithep {
 
     RefArray<XlSubJet> fSubJets[XlSubJet::nSubJetTypes];      //sub jets in the jet
 
-    ClassDef(XlFatJet, 6) // XlFatJet class
+    ClassDef(XlFatJet, 7) // XlFatJet class
   };
 
 }

--- a/PhysicsMod/src/PlotKineMod.cc
+++ b/PhysicsMod/src/PlotKineMod.cc
@@ -82,5 +82,5 @@ mithep::PlotKineMod::SlaveBegin()
 
   AddTH1(fMultHist, "hMultiplicity", ";Number of objects in " + fColName + ";", 10, 0., 10.);
 
-  //fMultHist->SetBit(TH1::kCanRebin); // CP: looks like bit disappeared in the new root version
+  fMultHist->SetCanExtend(TH1::kXaxis);
 }

--- a/bin/runOnDatasets.py
+++ b/bin/runOnDatasets.py
@@ -316,7 +316,7 @@ class CondorConfig(object):
             listWasGiven = False
     
         inputFiles = ['{book}/{dataset}/run.py', env.cmsswPack, 'env.sh']
-        for optionalInput in ['x509up', 'preExec.sh', 'postExec.sh']:
+        for optionalInput in [env.x509up, 'preExec.sh', 'postExec.sh']:
             if os.path.exists(env.workspace + '/' + optionalInput):
                 inputFiles.append(optionalInput)
 
@@ -1192,7 +1192,7 @@ if __name__ == '__main__':
         print ' Creating task', env.taskName
 
     env.x509up = 'x509up_u' + str(os.getuid())
-#    if not os.path.exists('/tmp/x509up_u' + str(os.getuid())):
+#    if not os.path.exists(env.x509up):
 #        message = ' x509 proxy missing. You will not be able to download files from T2 in case T3 cache does not exist.\n'
 #        message += ' Continue?'
 #        if not yes(message):

--- a/bin/runOnDatasets.py
+++ b/bin/runOnDatasets.py
@@ -1191,6 +1191,7 @@ if __name__ == '__main__':
     if newTask:
         print ' Creating task', env.taskName
 
+    env.x509up = 'x509up_u' + str(os.getuid())
 #    if not os.path.exists('/tmp/x509up_u' + str(os.getuid())):
 #        message = ' x509 proxy missing. You will not be able to download files from T2 in case T3 cache does not exist.\n'
 #        message += ' Continue?'

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -13,11 +13,10 @@ then
   exit 1
 fi
 
-if [ -e x509up ]
+if [ -e x509up_u* ]
 then
   # Certain LCG applications expect the proxy file to have a specific name
-  mv x509up x509up_u$(id -u)
-  export X509_USER_PROXY=x509up_u$(id -u)
+  export X509_USER_PROXY=$(pwd)/$(ls x509up_u*)
 fi
 
 # make sure you get a stack trace in case of failure


### PR DESCRIPTION
  * Egamma: moved supercluster variables to SuperCluster instead of having one each in Photon and Electron
  * FatJet: moved variables that need to be filled at production time from XlFatJet
  * PFCandidate: Cut out variables that weren't really used. Would like to slim down the Track object too but this needs more care to retain backward compatibility.